### PR TITLE
fix(modem-radios): time-bounded LBT and ERR_CHANNEL_BUSY handling

### DIFF
--- a/src/openhop_core/hardware/protocol_constants.py
+++ b/src/openhop_core/hardware/protocol_constants.py
@@ -67,6 +67,10 @@ ERR_INVALID_CONFIG = 0x06
 ERR_CAD_FAILED = 0x07
 ERR_RADIO_INIT = 0x08
 ERR_UNAUTHORIZED = 0x09
+# Firmware auto-CAD (CMD_SET_AUTO_CAD) refused a TX because the channel was
+# busy after all its retries. LBT feedback, not a failure: the host retries
+# within its own LBT time budget.
+ERR_CHANNEL_BUSY = 0x0E
 
 # ─── WIFI_STATUS mode codes ──────────────────────────────────────────
 # Matches firmware main.cpp::buildWifiStatusPayload
@@ -178,6 +182,7 @@ __all__ = [
     "ERR_CAD_FAILED",
     "ERR_RADIO_INIT",
     "ERR_UNAUTHORIZED",
+    "ERR_CHANNEL_BUSY",
     # WIFI_STATUS modes
     "WIFI_MODE_OFFLINE",
     "WIFI_MODE_STA_CONNECTING",

--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -207,7 +207,7 @@ class TCPLoRaRadio(_RadioBase):
         """One short jittered LBT retry delay, clamped to the remaining budget."""
         delay_ms = self.lbt_retry_interval_ms * random.uniform(0.5, 1.5)
         remaining_ms = (deadline - time.monotonic()) * 1000.0
-        return max(10.0, min(delay_ms, remaining_ms))
+        return max(0.0, min(delay_ms, remaining_ms))
 
     def begin(self) -> bool:
         """Open TCP connection, authenticate (if token set), push config.
@@ -277,6 +277,11 @@ class TCPLoRaRadio(_RadioBase):
             return None
 
         async with self._tx_lock:
+            # Log taxonomy, shared with the SPI radio: [LBT] is the
+            # listen-before-talk retry loop, [CAD] a single channel-activity
+            # scan, [TX] the transmit path. A nominal TX logs two DEBUG lines
+            # ("[LBT] Summary" and "[TX] Done"); contention adds bounded
+            # DEBUG retries, anomalies log at WARNING, failed sends at ERROR.
             lbt_backoff_delays: list[int] = []
 
             # Bounded in TIME rather than attempts: short jittered retries run
@@ -284,25 +289,40 @@ class TCPLoRaRadio(_RadioBase):
             # ERR_CHANNEL_BUSY retry below, so firmware-side auto-CAD refusals
             # draw from the same budget.
             lbt_deadline = time.monotonic() + self.lbt_max_wait_seconds
+            cad_checks = 0
+            modem_refusals = 0
+            outcome = "clear" if self.lbt_enabled else "off"
             if self.lbt_enabled:
                 while True:
+                    remaining = lbt_deadline - time.monotonic()
+                    if remaining <= 0:
+                        outcome = "forced"
+                        logger.warning(
+                            f"[LBT] Budget exhausted ({self.lbt_max_wait_seconds:.1f}s) - "
+                            "channel still busy, transmitting anyway"
+                        )
+                        break
                     try:
-                        channel_busy = await self._perform_cad(timeout=1.0)
+                        cad_checks += 1
+                        channel_busy = await self._perform_cad(timeout=min(1.0, remaining))
                     except Exception as e:
-                        logger.warning(f"CAD failed: {e}, proceeding with TX")
+                        outcome = "exception"
+                        logger.warning(
+                            f"[LBT] Channel check failed: {e}, proceeding with transmission"
+                        )
                         break
                     if not channel_busy:
-                        logger.debug("CAD clear")
                         break
                     if time.monotonic() >= lbt_deadline:
+                        outcome = "forced"
                         logger.warning(
-                            f"LBT budget exhausted ({self.lbt_max_wait_seconds:.1f}s) — "
+                            f"[LBT] Budget exhausted ({self.lbt_max_wait_seconds:.1f}s) - "
                             "channel still busy, transmitting anyway"
                         )
                         break
                     delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
                     lbt_backoff_delays.append(round(delay_ms))
-                    logger.debug(f"CAD busy — retrying in {delay_ms:.0f}ms")
+                    logger.debug(f"[LBT] Channel busy - retrying in {delay_ms:.0f}ms")
                     await asyncio.sleep(delay_ms / 1000.0)
 
             try:
@@ -324,18 +344,27 @@ class TCPLoRaRadio(_RadioBase):
                         self._last_modem_error == ERR_CHANNEL_BUSY
                         and time.monotonic() < lbt_deadline
                     ):
+                        modem_refusals += 1
                         delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
                         lbt_backoff_delays.append(round(delay_ms))
                         logger.debug(
-                            f"Modem reports channel busy — retrying TX in {delay_ms:.0f}ms"
+                            f"[LBT] Modem reports channel busy - retrying TX in {delay_ms:.0f}ms"
                         )
                         await asyncio.sleep(delay_ms / 1000.0)
                         continue
                     if self._last_modem_error == ERR_CHANNEL_BUSY:
                         # Unlike the host-side loop there is nothing to force
                         # here: the modem is alive and refusing, not wedged.
-                        logger.warning("Modem refused TX: channel busy for the whole LBT budget")
+                        outcome = "refused"
+                        modem_refusals += 1
+                        logger.warning("[LBT] Modem refused TX - channel busy for the whole budget")
                     break
+
+                logger.debug(
+                    f"[LBT] Summary: outcome={outcome} cad_checks={cad_checks} "
+                    f"modem_refusals={modem_refusals} "
+                    f"backoff_total={sum(lbt_backoff_delays):.0f}ms"
+                )
 
                 if resp is not None:
                     self._tx_count += 1
@@ -344,7 +373,7 @@ class TCPLoRaRadio(_RadioBase):
                         airtime_us = struct.unpack("<I", resp[:4])[0]
                     airtime_ms = airtime_us / 1000.0
 
-                    logger.debug(f"TX done: {len(data)}B, airtime={airtime_ms:.1f}ms")
+                    logger.debug(f"[TX] Done {len(data)}B airtime={airtime_ms:.0f}ms")
 
                     await self._send_command(
                         CMD_RX_START,
@@ -360,7 +389,7 @@ class TCPLoRaRadio(_RadioBase):
                         "lbt_channel_busy": len(lbt_backoff_delays) > 0,
                     }
                 else:
-                    logger.error("TX failed — no TX_DONE response")
+                    logger.error("[TX] Failed - no TX_DONE response")
                     await self._send_command(
                         CMD_RX_START,
                         b"",
@@ -370,7 +399,7 @@ class TCPLoRaRadio(_RadioBase):
                     return None
 
             except Exception as e:
-                logger.error(f"TX error: {e}")
+                logger.error(f"[TX] Error: {e}")
                 return None
 
     async def wait_for_rx(self) -> bytes:
@@ -920,7 +949,11 @@ class TCPLoRaRadio(_RadioBase):
 
         elif cmd == CMD_ERROR:
             err_code = payload[0] if payload else 0xFF
-            logger.warning(f"Modem error: 0x{err_code:02X}")
+            if err_code == ERR_CHANNEL_BUSY:
+                # LBT feedback, not an anomaly: the send loop retries it.
+                logger.debug(f"Modem error: 0x{err_code:02X} (channel busy)")
+            else:
+                logger.warning(f"Modem error: 0x{err_code:02X}")
             self._last_modem_error = err_code
             with self._response_lock:
                 for evt_cmd, evt in list(self._response_events.items()):
@@ -933,7 +966,7 @@ class TCPLoRaRadio(_RadioBase):
             # TX_DONE before the firmware's own timeout. Wake up whoever is
             # blocked on CMD_TX_DONE so the caller doesn't have to wait out
             # the full 10 s driver timeout.
-            logger.warning("Modem TX_FAIL — radio did not assert TX_DONE")
+            logger.warning("[TX] Modem TX_FAIL - radio did not assert TX_DONE")
             with self._response_lock:
                 evt = self._response_events.get(CMD_TX_DONE)
                 if evt is not None:
@@ -1003,9 +1036,13 @@ class TCPLoRaRadio(_RadioBase):
         )
         if resp and len(resp) >= 1:
             busy = resp[0] != 0
-            logger.debug(f"CAD: {'BUSY' if busy else 'CLEAR'}")
+            logger.debug(
+                "[CAD] BUSY - channel activity detected"
+                if busy
+                else "[CAD] CLEAR - no channel activity detected"
+            )
             return busy
-        logger.warning("CAD no response — assuming clear")
+        logger.warning("[CAD] No response - assuming clear")
         return False
 
     # ── Config setters — live push to firmware ───────────────
@@ -1165,7 +1202,7 @@ class TCPLoRaRadio(_RadioBase):
             wait_timeout=4.0,
         )
         logger.info(
-            "CAD settings pushed symbols=%s peak=%s min=%s: %s",
+            "[CAD] Settings pushed symbols=%s peak=%s min=%s: %s",
             self._custom_cad_symbol_num or 2,
             self._custom_cad_peak,
             self._custom_cad_min,

--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -61,6 +61,7 @@ from .protocol_constants import (
     CMD_TX_DONE,
     CMD_TX_FAIL,
     CMD_TX_REQUEST,
+    ERR_CHANNEL_BUSY,
     ERR_UNAUTHORIZED,
     MAX_LORA_PAYLOAD,
     PROTO_SYNC,
@@ -116,6 +117,8 @@ class TCPLoRaRadio(_RadioBase):
         preamble_length: int = 16,
         lbt_enabled: bool = True,
         lbt_max_attempts: int = 5,
+        lbt_max_wait_seconds: float = 4.0,
+        lbt_retry_interval_ms: int = 200,
         connect_timeout: float = 5.0,
     ):
         self.host = host
@@ -132,9 +135,18 @@ class TCPLoRaRadio(_RadioBase):
         self.sync_word = sync_word
         self.preamble_length = preamble_length
 
-        # LBT (Listen Before Talk) via CAD
+        # LBT (Listen Before Talk) via CAD, bounded in TIME rather than
+        # attempts, so an occupation longer than the budget cannot leave two
+        # neighbours forcing their TX in lockstep. Defaults match MeshCore
+        # (4 s cap, 200 ms retry); the jitter keeps two nodes decorrelated.
+        # lbt_max_attempts is accepted for call-site compatibility only.
         self.lbt_enabled = lbt_enabled
         self.lbt_max_attempts = lbt_max_attempts
+        self.lbt_max_wait_seconds = max(0.5, float(lbt_max_wait_seconds))
+        self.lbt_retry_interval_ms = max(20, int(lbt_retry_interval_ms))
+        # Last CMD_ERROR code seen, so send() can tell a firmware-side
+        # auto-CAD refusal (ERR_CHANNEL_BUSY) from a real TX failure.
+        self._last_modem_error = None  # int error code, or None
 
         # State
         self._sock: Optional[socket.socket] = None
@@ -190,6 +202,12 @@ class TCPLoRaRadio(_RadioBase):
     # ══════════════════════════════════════════════════════════
     # LoRaRadio interface
     # ══════════════════════════════════════════════════════════
+
+    def _lbt_retry_delay_ms(self, deadline: float) -> float:
+        """One short jittered LBT retry delay, clamped to the remaining budget."""
+        delay_ms = self.lbt_retry_interval_ms * random.uniform(0.5, 1.5)
+        remaining_ms = (deadline - time.monotonic()) * 1000.0
+        return max(10.0, min(delay_ms, remaining_ms))
 
     def begin(self) -> bool:
         """Open TCP connection, authenticate (if token set), push config.
@@ -261,37 +279,63 @@ class TCPLoRaRadio(_RadioBase):
         async with self._tx_lock:
             lbt_backoff_delays: list[float] = []
 
+            # Bounded in TIME rather than attempts: short jittered retries run
+            # for the whole budget. The deadline is shared with the
+            # ERR_CHANNEL_BUSY retry below, so firmware-side auto-CAD refusals
+            # draw from the same budget.
+            lbt_deadline = time.monotonic() + self.lbt_max_wait_seconds
             if self.lbt_enabled:
-                for attempt in range(self.lbt_max_attempts):
+                while True:
                     try:
                         channel_busy = await self._perform_cad(timeout=1.0)
-                        if not channel_busy:
-                            logger.debug(f"CAD clear after {attempt + 1} attempt(s)")
-                            break
-                        else:
-                            logger.debug("CAD busy — channel activity detected")
-                            if attempt < self.lbt_max_attempts - 1:
-                                base_delay = random.randint(50, 200)
-                                backoff_ms = min(base_delay * (2**attempt), 5000)
-                                lbt_backoff_delays.append(float(backoff_ms))
-                                logger.debug(
-                                    f"CAD backoff {backoff_ms}ms "
-                                    f"(attempt {attempt + 1}/{self.lbt_max_attempts})"
-                                )
-                                await asyncio.sleep(backoff_ms / 1000.0)
-                            else:
-                                logger.warning("CAD max attempts — transmitting anyway")
                     except Exception as e:
                         logger.warning(f"CAD failed: {e}, proceeding with TX")
                         break
+                    if not channel_busy:
+                        logger.debug("CAD clear")
+                        break
+                    if time.monotonic() >= lbt_deadline:
+                        logger.warning(
+                            f"LBT budget exhausted ({self.lbt_max_wait_seconds:.1f}s) — "
+                            "channel still busy, transmitting anyway"
+                        )
+                        break
+                    delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
+                    lbt_backoff_delays.append(delay_ms)
+                    logger.debug(f"CAD busy — retrying in {delay_ms:.0f}ms")
+                    await asyncio.sleep(delay_ms / 1000.0)
 
             try:
-                resp = await self._send_command(
-                    CMD_TX_REQUEST,
-                    data,
-                    expect_cmd=CMD_TX_DONE,
-                    timeout=10.0,
-                )
+                while True:
+                    self._last_modem_error = None
+                    resp = await self._send_command(
+                        CMD_TX_REQUEST,
+                        data,
+                        expect_cmd=CMD_TX_DONE,
+                        timeout=10.0,
+                    )
+                    if resp is not None:
+                        break
+                    # Firmware-side auto-CAD (CMD_SET_AUTO_CAD) refuses a busy
+                    # channel with ERR_CHANNEL_BUSY instead of trampling a
+                    # neighbour. That is LBT feedback, not a failure: retry
+                    # within the same time budget the host-side loop uses.
+                    if (
+                        self._last_modem_error == ERR_CHANNEL_BUSY
+                        and time.monotonic() < lbt_deadline
+                    ):
+                        delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
+                        lbt_backoff_delays.append(delay_ms)
+                        logger.debug(
+                            f"Modem reports channel busy — retrying TX in {delay_ms:.0f}ms"
+                        )
+                        await asyncio.sleep(delay_ms / 1000.0)
+                        continue
+                    if self._last_modem_error == ERR_CHANNEL_BUSY:
+                        # Unlike the host-side loop there is nothing to force
+                        # here: the modem is alive and refusing, not wedged.
+                        logger.warning("Modem refused TX: channel busy for the whole LBT budget")
+                    break
 
                 if resp is not None:
                     self._tx_count += 1
@@ -877,6 +921,7 @@ class TCPLoRaRadio(_RadioBase):
         elif cmd == CMD_ERROR:
             err_code = payload[0] if payload else 0xFF
             logger.warning(f"Modem error: 0x{err_code:02X}")
+            self._last_modem_error = err_code
             with self._response_lock:
                 for evt_cmd, evt in list(self._response_events.items()):
                     self._response_data[evt_cmd] = None

--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -277,7 +277,7 @@ class TCPLoRaRadio(_RadioBase):
             return None
 
         async with self._tx_lock:
-            lbt_backoff_delays: list[float] = []
+            lbt_backoff_delays: list[int] = []
 
             # Bounded in TIME rather than attempts: short jittered retries run
             # for the whole budget. The deadline is shared with the
@@ -301,7 +301,7 @@ class TCPLoRaRadio(_RadioBase):
                         )
                         break
                     delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
-                    lbt_backoff_delays.append(delay_ms)
+                    lbt_backoff_delays.append(round(delay_ms))
                     logger.debug(f"CAD busy — retrying in {delay_ms:.0f}ms")
                     await asyncio.sleep(delay_ms / 1000.0)
 
@@ -325,7 +325,7 @@ class TCPLoRaRadio(_RadioBase):
                         and time.monotonic() < lbt_deadline
                     ):
                         delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
-                        lbt_backoff_delays.append(delay_ms)
+                        lbt_backoff_delays.append(round(delay_ms))
                         logger.debug(
                             f"Modem reports channel busy — retrying TX in {delay_ms:.0f}ms"
                         )

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -212,7 +212,7 @@ class USBLoRaRadio(_RadioBase):
         """One short jittered LBT retry delay, clamped to the remaining budget."""
         delay_ms = self.lbt_retry_interval_ms * random.uniform(0.5, 1.5)
         remaining_ms = (deadline - time.monotonic()) * 1000.0
-        return max(10.0, min(delay_ms, remaining_ms))
+        return max(0.0, min(delay_ms, remaining_ms))
 
     def begin(self) -> bool:
         """Initialize USB serial connection and configure the modem radio."""
@@ -302,9 +302,17 @@ class USBLoRaRadio(_RadioBase):
             outcome = "clear" if self.lbt_enabled else "off"
             if self.lbt_enabled:
                 while True:
+                    remaining = lbt_deadline - time.monotonic()
+                    if remaining <= 0:
+                        outcome = "forced"
+                        logger.warning(
+                            f"[LBT] Budget exhausted ({self.lbt_max_wait_seconds:.1f}s) - "
+                            "channel still busy, transmitting anyway"
+                        )
+                        break
                     try:
                         cad_checks += 1
-                        channel_busy = await self._perform_cad(timeout=1.0)
+                        channel_busy = await self._perform_cad(timeout=min(1.0, remaining))
                     except Exception as e:
                         outcome = "exception"
                         logger.warning(

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -66,6 +66,7 @@ from .protocol_constants import (
     CMD_VERSION_RESP,
     CMD_WIFI_RESET,
     CMD_WIFI_STATUS,
+    ERR_CHANNEL_BUSY,
     MAX_LORA_PAYLOAD,
     PROTO_SYNC,
     RADIO_CONFIG_FMT,
@@ -124,6 +125,8 @@ class USBLoRaRadio(_RadioBase):
         preamble_length: int = 16,
         lbt_enabled: bool = True,
         lbt_max_attempts: int = 5,
+        lbt_max_wait_seconds: float = 4.0,
+        lbt_retry_interval_ms: int = 200,
     ):
         self.port = port
         self.baudrate = baudrate
@@ -137,9 +140,18 @@ class USBLoRaRadio(_RadioBase):
         self.sync_word = sync_word
         self.preamble_length = preamble_length
 
-        # LBT (Listen Before Talk) via CAD
+        # LBT (Listen Before Talk) via CAD, bounded in TIME rather than
+        # attempts, so an occupation longer than the budget cannot leave two
+        # neighbours forcing their TX in lockstep. Defaults match MeshCore
+        # (4 s cap, 200 ms retry); the jitter keeps two nodes decorrelated.
+        # lbt_max_attempts is accepted for call-site compatibility only.
         self.lbt_enabled = lbt_enabled
         self.lbt_max_attempts = lbt_max_attempts
+        self.lbt_max_wait_seconds = max(0.5, float(lbt_max_wait_seconds))
+        self.lbt_retry_interval_ms = max(20, int(lbt_retry_interval_ms))
+        # Last CMD_ERROR code seen, so send() can tell a firmware-side
+        # auto-CAD refusal (ERR_CHANNEL_BUSY) from a real TX failure.
+        self._last_modem_error = None  # int error code, or None
 
         # State
         self._serial: Optional[serial.Serial] = None
@@ -195,6 +207,12 @@ class USBLoRaRadio(_RadioBase):
     # ══════════════════════════════════════════════════════════
     # LoRaRadio interface implementation
     # ══════════════════════════════════════════════════════════
+
+    def _lbt_retry_delay_ms(self, deadline: float) -> float:
+        """One short jittered LBT retry delay, clamped to the remaining budget."""
+        delay_ms = self.lbt_retry_interval_ms * random.uniform(0.5, 1.5)
+        remaining_ms = (deadline - time.monotonic()) * 1000.0
+        return max(10.0, min(delay_ms, remaining_ms))
 
     def begin(self) -> bool:
         """Initialize USB serial connection and configure the modem radio."""
@@ -269,38 +287,64 @@ class USBLoRaRadio(_RadioBase):
             lbt_backoff_delays: list[float] = []
 
             # ── Listen Before Talk (CAD) ─────────────────────
+            # Bounded in TIME rather than attempts: short jittered retries run
+            # for the whole budget. The deadline is shared with the
+            # ERR_CHANNEL_BUSY retry below, so firmware-side auto-CAD refusals
+            # draw from the same budget.
+            lbt_deadline = time.monotonic() + self.lbt_max_wait_seconds
             if self.lbt_enabled:
-                for attempt in range(self.lbt_max_attempts):
+                while True:
                     try:
                         channel_busy = await self._perform_cad(timeout=1.0)
-                        if not channel_busy:
-                            logger.debug(f"CAD clear after {attempt + 1} attempt(s)")
-                            break
-                        else:
-                            logger.debug("CAD busy — channel activity detected")
-                            if attempt < self.lbt_max_attempts - 1:
-                                base_delay = random.randint(50, 200)
-                                backoff_ms = min(base_delay * (2**attempt), 5000)
-                                lbt_backoff_delays.append(float(backoff_ms))
-                                logger.debug(
-                                    f"CAD backoff {backoff_ms}ms "
-                                    f"(attempt {attempt + 1}/{self.lbt_max_attempts})"
-                                )
-                                await asyncio.sleep(backoff_ms / 1000.0)
-                            else:
-                                logger.warning("CAD max attempts — transmitting anyway")
                     except Exception as e:
                         logger.warning(f"CAD failed: {e}, proceeding with TX")
                         break
+                    if not channel_busy:
+                        logger.debug("CAD clear")
+                        break
+                    if time.monotonic() >= lbt_deadline:
+                        logger.warning(
+                            f"LBT budget exhausted ({self.lbt_max_wait_seconds:.1f}s) — "
+                            "channel still busy, transmitting anyway"
+                        )
+                        break
+                    delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
+                    lbt_backoff_delays.append(delay_ms)
+                    logger.debug(f"CAD busy — retrying in {delay_ms:.0f}ms")
+                    await asyncio.sleep(delay_ms / 1000.0)
 
             # ── Transmit ─────────────────────────────────────
             try:
-                resp = await self._send_command(
-                    CMD_TX_REQUEST,
-                    data,
-                    expect_cmd=CMD_TX_DONE,
-                    timeout=10.0,
-                )
+                while True:
+                    self._last_modem_error = None
+                    resp = await self._send_command(
+                        CMD_TX_REQUEST,
+                        data,
+                        expect_cmd=CMD_TX_DONE,
+                        timeout=10.0,
+                    )
+                    if resp is not None:
+                        break
+                    # Firmware-side auto-CAD (CMD_SET_AUTO_CAD) refuses a busy
+                    # channel with ERR_CHANNEL_BUSY instead of trampling a
+                    # neighbour. That is LBT feedback, not a failure: retry
+                    # within the same time budget the host-side loop uses.
+                    if (
+                        self._last_modem_error == ERR_CHANNEL_BUSY
+                        and time.monotonic() < lbt_deadline
+                    ):
+                        delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
+                        lbt_backoff_delays.append(delay_ms)
+                        logger.debug(
+                            f"Modem reports channel busy — retrying TX in {delay_ms:.0f}ms"
+                        )
+                        await asyncio.sleep(delay_ms / 1000.0)
+                        continue
+                    if self._last_modem_error == ERR_CHANNEL_BUSY:
+                        # Unlike the host-side loop there is nothing to force
+                        # here: the modem is alive and refusing, not wedged.
+                        logger.warning("Modem refused TX: channel busy for the whole LBT budget")
+                    break
 
                 if resp is not None:
                     self._tx_count += 1
@@ -1024,6 +1068,7 @@ class USBLoRaRadio(_RadioBase):
         elif cmd == CMD_ERROR:
             err_code = payload[0] if len(payload) > 0 else 0xFF
             logger.warning(f"Modem error: 0x{err_code:02X}")
+            self._last_modem_error = err_code
             # Also signal any waiting command in case the error
             # is a response to our command
             with self._response_lock:

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -274,7 +274,7 @@ class USBLoRaRadio(_RadioBase):
             {
                 "airtime_ms": float,
                 "lbt_attempts": int,
-                "lbt_backoff_delays_ms": list[float],
+                "lbt_backoff_delays_ms": list[int],
                 "lbt_channel_busy": bool,
             }
         Returns None on failure.
@@ -284,7 +284,7 @@ class USBLoRaRadio(_RadioBase):
             return None
 
         async with self._tx_lock:
-            lbt_backoff_delays: list[float] = []
+            lbt_backoff_delays: list[int] = []
 
             # ── Listen Before Talk (CAD) ─────────────────────
             # Bounded in TIME rather than attempts: short jittered retries run
@@ -309,7 +309,7 @@ class USBLoRaRadio(_RadioBase):
                         )
                         break
                     delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
-                    lbt_backoff_delays.append(delay_ms)
+                    lbt_backoff_delays.append(round(delay_ms))
                     logger.debug(f"CAD busy — retrying in {delay_ms:.0f}ms")
                     await asyncio.sleep(delay_ms / 1000.0)
 
@@ -334,7 +334,7 @@ class USBLoRaRadio(_RadioBase):
                         and time.monotonic() < lbt_deadline
                     ):
                         delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
-                        lbt_backoff_delays.append(delay_ms)
+                        lbt_backoff_delays.append(round(delay_ms))
                         logger.debug(
                             f"Modem reports channel busy — retrying TX in {delay_ms:.0f}ms"
                         )

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -284,6 +284,11 @@ class USBLoRaRadio(_RadioBase):
             return None
 
         async with self._tx_lock:
+            # Log taxonomy, shared with the SPI radio: [LBT] is the
+            # listen-before-talk retry loop, [CAD] a single channel-activity
+            # scan, [TX] the transmit path. A nominal TX logs two DEBUG lines
+            # ("[LBT] Summary" and "[TX] Done"); contention adds bounded
+            # DEBUG retries, anomalies log at WARNING, failed sends at ERROR.
             lbt_backoff_delays: list[int] = []
 
             # ── Listen Before Talk (CAD) ─────────────────────
@@ -292,25 +297,32 @@ class USBLoRaRadio(_RadioBase):
             # ERR_CHANNEL_BUSY retry below, so firmware-side auto-CAD refusals
             # draw from the same budget.
             lbt_deadline = time.monotonic() + self.lbt_max_wait_seconds
+            cad_checks = 0
+            modem_refusals = 0
+            outcome = "clear" if self.lbt_enabled else "off"
             if self.lbt_enabled:
                 while True:
                     try:
+                        cad_checks += 1
                         channel_busy = await self._perform_cad(timeout=1.0)
                     except Exception as e:
-                        logger.warning(f"CAD failed: {e}, proceeding with TX")
+                        outcome = "exception"
+                        logger.warning(
+                            f"[LBT] Channel check failed: {e}, proceeding with transmission"
+                        )
                         break
                     if not channel_busy:
-                        logger.debug("CAD clear")
                         break
                     if time.monotonic() >= lbt_deadline:
+                        outcome = "forced"
                         logger.warning(
-                            f"LBT budget exhausted ({self.lbt_max_wait_seconds:.1f}s) — "
+                            f"[LBT] Budget exhausted ({self.lbt_max_wait_seconds:.1f}s) - "
                             "channel still busy, transmitting anyway"
                         )
                         break
                     delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
                     lbt_backoff_delays.append(round(delay_ms))
-                    logger.debug(f"CAD busy — retrying in {delay_ms:.0f}ms")
+                    logger.debug(f"[LBT] Channel busy - retrying in {delay_ms:.0f}ms")
                     await asyncio.sleep(delay_ms / 1000.0)
 
             # ── Transmit ─────────────────────────────────────
@@ -333,18 +345,27 @@ class USBLoRaRadio(_RadioBase):
                         self._last_modem_error == ERR_CHANNEL_BUSY
                         and time.monotonic() < lbt_deadline
                     ):
+                        modem_refusals += 1
                         delay_ms = self._lbt_retry_delay_ms(lbt_deadline)
                         lbt_backoff_delays.append(round(delay_ms))
                         logger.debug(
-                            f"Modem reports channel busy — retrying TX in {delay_ms:.0f}ms"
+                            f"[LBT] Modem reports channel busy - retrying TX in {delay_ms:.0f}ms"
                         )
                         await asyncio.sleep(delay_ms / 1000.0)
                         continue
                     if self._last_modem_error == ERR_CHANNEL_BUSY:
                         # Unlike the host-side loop there is nothing to force
                         # here: the modem is alive and refusing, not wedged.
-                        logger.warning("Modem refused TX: channel busy for the whole LBT budget")
+                        outcome = "refused"
+                        modem_refusals += 1
+                        logger.warning("[LBT] Modem refused TX - channel busy for the whole budget")
                     break
+
+                logger.debug(
+                    f"[LBT] Summary: outcome={outcome} cad_checks={cad_checks} "
+                    f"modem_refusals={modem_refusals} "
+                    f"backoff_total={sum(lbt_backoff_delays):.0f}ms"
+                )
 
                 if resp is not None:
                     self._tx_count += 1
@@ -355,7 +376,7 @@ class USBLoRaRadio(_RadioBase):
                         airtime_us = struct.unpack("<I", resp[:4])[0]
                     airtime_ms = airtime_us / 1000.0
 
-                    logger.debug(f"TX done: {len(data)}B, airtime={airtime_ms:.1f}ms")
+                    logger.debug(f"[TX] Done {len(data)}B airtime={airtime_ms:.0f}ms")
 
                     # Restore RX continuous mode
                     await self._send_command(
@@ -372,7 +393,7 @@ class USBLoRaRadio(_RadioBase):
                         "lbt_channel_busy": len(lbt_backoff_delays) > 0,
                     }
                 else:
-                    logger.error("TX failed — no TX_DONE response")
+                    logger.error("[TX] Failed - no TX_DONE response")
                     # Try to restore RX anyway
                     await self._send_command(
                         CMD_RX_START,
@@ -383,7 +404,7 @@ class USBLoRaRadio(_RadioBase):
                     return None
 
             except Exception as e:
-                logger.error(f"TX error: {e}")
+                logger.error(f"[TX] Error: {e}")
                 return None
 
     async def wait_for_rx(self) -> bytes:
@@ -1067,7 +1088,11 @@ class USBLoRaRadio(_RadioBase):
 
         elif cmd == CMD_ERROR:
             err_code = payload[0] if len(payload) > 0 else 0xFF
-            logger.warning(f"Modem error: 0x{err_code:02X}")
+            if err_code == ERR_CHANNEL_BUSY:
+                # LBT feedback, not an anomaly: the send loop retries it.
+                logger.debug(f"Modem error: 0x{err_code:02X} (channel busy)")
+            else:
+                logger.warning(f"Modem error: 0x{err_code:02X}")
             self._last_modem_error = err_code
             # Also signal any waiting command in case the error
             # is a response to our command
@@ -1082,7 +1107,7 @@ class USBLoRaRadio(_RadioBase):
             # TX_DONE before the firmware's own timeout. Wake up whoever is
             # blocked on CMD_TX_DONE so the caller doesn't sit on the full
             # driver timeout.
-            logger.warning("Modem TX_FAIL — radio did not assert TX_DONE")
+            logger.warning("[TX] Modem TX_FAIL - radio did not assert TX_DONE")
             with self._response_lock:
                 evt = self._response_events.get(CMD_TX_DONE)
                 if evt is not None:
@@ -1154,10 +1179,14 @@ class USBLoRaRadio(_RadioBase):
         )
         if resp and len(resp) >= 1:
             busy = resp[0] != 0
-            logger.debug(f"CAD: {'BUSY' if busy else 'CLEAR'}")
+            logger.debug(
+                "[CAD] BUSY - channel activity detected"
+                if busy
+                else "[CAD] CLEAR - no channel activity detected"
+            )
             return busy
         else:
-            logger.warning("CAD no response — assuming clear")
+            logger.warning("[CAD] No response - assuming clear")
             return False
 
     # ── Config setters (for runtime reconfiguration) ──────────

--- a/tests/test_modem_lbt.py
+++ b/tests/test_modem_lbt.py
@@ -9,12 +9,15 @@ neighbour. That refusal is LBT feedback, retried within the same time budget,
 and the send fails without forcing when the modem keeps refusing.
 """
 
+import asyncio
 import struct
 import time
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from openhop_core.hardware.protocol_constants import (
+    CMD_ERROR,
     CMD_RX_START,
+    CMD_TX_DONE,
     CMD_TX_REQUEST,
     ERR_CHANNEL_BUSY,
 )
@@ -71,6 +74,39 @@ def _script_modem(radio, tx_responses):
     return calls
 
 
+async def _assert_busy_error_wakes_tx_waiter(radio):
+    radio._event_loop = asyncio.get_running_loop()
+    if isinstance(radio, USBLoRaRadio):
+        radio._serial = Mock()
+        radio._serial.is_open = True
+        radio._connected_event.set()
+    else:
+        radio._sock = Mock()
+        radio._sock_write = Mock()
+
+    pending = asyncio.create_task(
+        radio._send_command(
+            CMD_TX_REQUEST,
+            b"payload",
+            expect_cmd=CMD_TX_DONE,
+            timeout=0.5,
+        )
+    )
+    await asyncio.sleep(0)
+    radio._dispatch_frame(CMD_ERROR, bytes([ERR_CHANNEL_BUSY]))
+
+    assert await asyncio.wait_for(pending, timeout=0.1) is None
+    assert radio._last_modem_error == ERR_CHANNEL_BUSY
+
+
+async def test_usb_busy_error_dispatch_wakes_tx_waiter():
+    await _assert_busy_error_wakes_tx_waiter(_usb_radio(lbt_enabled=False))
+
+
+async def test_tcp_busy_error_dispatch_wakes_tx_waiter():
+    await _assert_busy_error_wakes_tx_waiter(_tcp_radio(lbt_enabled=False))
+
+
 # ─── time-bounded host-side CAD loop ─────────────────────────────────
 
 
@@ -87,8 +123,10 @@ async def test_usb_lbt_budget_is_time_bounded():
     # Many short checks within the budget; the exact count is timing-dependent.
     assert radio._perform_cad.await_count > 5
     assert 0.4 <= elapsed <= 2.0
-    assert sum(result["lbt_backoff_delays_ms"]) <= 600.0
-    assert all(10.0 <= d <= 30.0 for d in result["lbt_backoff_delays_ms"])
+    delays = result["lbt_backoff_delays_ms"]
+    assert sum(delays) <= 600.0
+    assert all(10.0 <= d <= 30.0 for d in delays[:-1])
+    assert 0.0 <= delays[-1] <= 30.0  # final wait is clamped to the remaining budget
 
 
 async def test_usb_lbt_clear_channel_has_no_delays():
@@ -115,6 +153,35 @@ async def test_tcp_lbt_budget_is_time_bounded():
     assert result is not None
     assert radio._perform_cad.await_count > 5
     assert 0.4 <= elapsed <= 2.0
+
+
+async def _assert_slow_cad_respects_deadline(radio):
+    seen_timeouts = []
+
+    async def slow_busy(timeout):
+        seen_timeouts.append(timeout)
+        await asyncio.sleep(timeout)
+        return True
+
+    radio._perform_cad = AsyncMock(side_effect=slow_busy)
+    _script_modem(radio, [TX_DONE_PAYLOAD])
+
+    started = time.monotonic()
+    result = await radio.send(b"payload")
+    elapsed = time.monotonic() - started
+
+    assert result is not None
+    assert seen_timeouts
+    assert max(seen_timeouts) <= radio.lbt_max_wait_seconds
+    assert 0.4 <= elapsed <= 0.8
+
+
+async def test_usb_slow_cad_call_is_clamped_to_remaining_budget():
+    await _assert_slow_cad_respects_deadline(_usb_radio())
+
+
+async def test_tcp_slow_cad_call_is_clamped_to_remaining_budget():
+    await _assert_slow_cad_respects_deadline(_tcp_radio())
 
 
 # ─── ERR_CHANNEL_BUSY: firmware auto-CAD refusal is LBT feedback ─────
@@ -177,9 +244,7 @@ async def test_tcp_modem_busy_refusal_is_retried_within_budget():
 
 
 def test_lbt_knob_clamps_and_defaults():
-    clamped = USBLoRaRadio(
-        port="/dev/null", lbt_max_wait_seconds=0.0, lbt_retry_interval_ms=5
-    )
+    clamped = USBLoRaRadio(port="/dev/null", lbt_max_wait_seconds=0.0, lbt_retry_interval_ms=5)
     assert clamped.lbt_max_wait_seconds == 0.5
     assert clamped.lbt_retry_interval_ms == 20
 

--- a/tests/test_modem_lbt.py
+++ b/tests/test_modem_lbt.py
@@ -1,0 +1,191 @@
+"""Tests for the USB/TCP modem Listen-Before-Talk path.
+
+Mirrors the SPI path: LBT is bounded in TIME, not in attempts, so short
+jittered retries run for the whole budget however long the occupation lasts.
+
+Also covers ERR_CHANNEL_BUSY: with firmware auto-CAD enabled
+(CMD_SET_AUTO_CAD) the modem refuses a busy channel instead of trampling a
+neighbour. That refusal is LBT feedback, retried within the same time budget,
+and the send fails without forcing when the modem keeps refusing.
+"""
+
+import struct
+import time
+from unittest.mock import AsyncMock
+
+from openhop_core.hardware.protocol_constants import (
+    CMD_RX_START,
+    CMD_TX_REQUEST,
+    ERR_CHANNEL_BUSY,
+)
+from openhop_core.hardware.tcp_radio import TCPLoRaRadio
+from openhop_core.hardware.usb_radio import USBLoRaRadio
+
+TX_DONE_PAYLOAD = struct.pack("<I", 12_000)  # 12 ms airtime
+
+
+def _usb_radio(**kwargs) -> USBLoRaRadio:
+    radio = USBLoRaRadio(
+        port="/dev/null",
+        lbt_max_wait_seconds=kwargs.pop("lbt_max_wait_seconds", 0.5),
+        lbt_retry_interval_ms=kwargs.pop("lbt_retry_interval_ms", 20),
+        **kwargs,
+    )
+    radio._initialized = True  # begin() never runs: transport is stubbed
+    return radio
+
+
+def _tcp_radio(**kwargs) -> TCPLoRaRadio:
+    radio = TCPLoRaRadio(
+        host="modem.invalid",
+        lbt_max_wait_seconds=kwargs.pop("lbt_max_wait_seconds", 0.5),
+        lbt_retry_interval_ms=kwargs.pop("lbt_retry_interval_ms", 20),
+        **kwargs,
+    )
+    radio._initialized = True
+    return radio
+
+
+def _script_modem(radio, tx_responses):
+    """Stub _send_command: consume one scripted entry per CMD_TX_REQUEST,
+    answer every other command (e.g. CMD_RX_START) with success.
+
+    An entry is either bytes (returned as the TX_DONE payload) or an error
+    code (the modem answered CMD_ERROR: record it and return None, exactly
+    like the real dispatch path does).
+    """
+    calls = {"tx": 0, "other": []}
+
+    async def _impl(cmd, payload=b"", expect_cmd=None, timeout=None):
+        if cmd == CMD_TX_REQUEST:
+            calls["tx"] += 1
+            entry = tx_responses.pop(0) if tx_responses else TX_DONE_PAYLOAD
+            if isinstance(entry, bytes):
+                return entry
+            radio._last_modem_error = entry
+            return None
+        calls["other"].append(cmd)
+        return b""
+
+    radio._send_command = AsyncMock(side_effect=_impl)
+    return calls
+
+
+# ─── time-bounded host-side CAD loop ─────────────────────────────────
+
+
+async def test_usb_lbt_budget_is_time_bounded():
+    radio = _usb_radio()
+    radio._perform_cad = AsyncMock(return_value=True)  # channel never clears
+    _script_modem(radio, [TX_DONE_PAYLOAD])
+
+    started = time.monotonic()
+    result = await radio.send(b"payload")
+    elapsed = time.monotonic() - started
+
+    assert result is not None  # forced TX at budget exhaustion, loudly logged
+    # Many short checks within the budget; the exact count is timing-dependent.
+    assert radio._perform_cad.await_count > 5
+    assert 0.4 <= elapsed <= 2.0
+    assert sum(result["lbt_backoff_delays_ms"]) <= 600.0
+    assert all(10.0 <= d <= 30.0 for d in result["lbt_backoff_delays_ms"])
+
+
+async def test_usb_lbt_clear_channel_has_no_delays():
+    radio = _usb_radio()
+    radio._perform_cad = AsyncMock(return_value=False)
+    _script_modem(radio, [TX_DONE_PAYLOAD])
+
+    result = await radio.send(b"payload")
+
+    assert result is not None
+    assert result["lbt_backoff_delays_ms"] == []
+    assert result["lbt_channel_busy"] is False
+
+
+async def test_tcp_lbt_budget_is_time_bounded():
+    radio = _tcp_radio()
+    radio._perform_cad = AsyncMock(return_value=True)
+    _script_modem(radio, [TX_DONE_PAYLOAD])
+
+    started = time.monotonic()
+    result = await radio.send(b"payload")
+    elapsed = time.monotonic() - started
+
+    assert result is not None
+    assert radio._perform_cad.await_count > 5
+    assert 0.4 <= elapsed <= 2.0
+
+
+# ─── ERR_CHANNEL_BUSY: firmware auto-CAD refusal is LBT feedback ─────
+
+
+async def test_usb_modem_busy_refusal_is_retried_within_budget():
+    """The modem answering ERR_CHANNEL_BUSY to CMD_TX_REQUEST means its own
+    auto-CAD saw a busy channel: retry within the LBT time budget instead of
+    reporting a TX failure."""
+    radio = _usb_radio(lbt_enabled=False)  # isolate the modem-side path
+    calls = _script_modem(radio, [ERR_CHANNEL_BUSY, ERR_CHANNEL_BUSY, TX_DONE_PAYLOAD])
+
+    result = await radio.send(b"payload")
+
+    assert result is not None
+    assert calls["tx"] == 3
+    assert len(result["lbt_backoff_delays_ms"]) == 2  # one wait per refusal
+    assert result["lbt_channel_busy"] is True
+    assert CMD_RX_START in calls["other"]  # RX restored after success
+
+
+async def test_usb_modem_busy_for_whole_budget_fails_without_forcing():
+    """Unlike the host-side loop there is nothing to force through a modem
+    that keeps refusing: it is alive and answering, not wedged. send()
+    reports the failure once the budget is exhausted."""
+    radio = _usb_radio(lbt_enabled=False)
+    calls = _script_modem(radio, [ERR_CHANNEL_BUSY] * 1000)
+
+    started = time.monotonic()
+    result = await radio.send(b"payload")
+    elapsed = time.monotonic() - started
+
+    assert result is None
+    assert 0.4 <= elapsed <= 2.0  # bounded by the budget, not the 1000 refusals
+    assert 2 < calls["tx"] < 100
+
+
+async def test_usb_non_busy_error_is_not_retried():
+    radio = _usb_radio(lbt_enabled=False)
+    calls = _script_modem(radio, [0x04])  # ERR_TX_TIMEOUT: a real failure
+
+    result = await radio.send(b"payload")
+
+    assert result is None
+    assert calls["tx"] == 1
+
+
+async def test_tcp_modem_busy_refusal_is_retried_within_budget():
+    radio = _tcp_radio(lbt_enabled=False)
+    calls = _script_modem(radio, [ERR_CHANNEL_BUSY, TX_DONE_PAYLOAD])
+
+    result = await radio.send(b"payload")
+
+    assert result is not None
+    assert calls["tx"] == 2
+    assert len(result["lbt_backoff_delays_ms"]) == 1
+
+
+# ─── knobs ───────────────────────────────────────────────────────────
+
+
+def test_lbt_knob_clamps_and_defaults():
+    clamped = USBLoRaRadio(
+        port="/dev/null", lbt_max_wait_seconds=0.0, lbt_retry_interval_ms=5
+    )
+    assert clamped.lbt_max_wait_seconds == 0.5
+    assert clamped.lbt_retry_interval_ms == 20
+
+    default_usb = USBLoRaRadio(port="/dev/null")
+    default_tcp = TCPLoRaRadio(host="modem.invalid")
+    for radio in (default_usb, default_tcp):
+        # Matches MeshCore: getCADFailMaxDuration() 4 s, 200 ms retry.
+        assert radio.lbt_max_wait_seconds == 4.0
+        assert radio.lbt_retry_interval_ms == 200


### PR DESCRIPTION
## Problem

Companion to #116 (SPI): the USB and TCP modem drivers have the same LBT defect, plus a protocol gap of their own.

**1. LBT bounded in attempts, not time.** Same 5-attempt exponential scheme (≈1.9 s average total budget) followed by a blind `"transmitting anyway"`. Two co-located repeaters held by one long occupation exhaust their budgets together and collide — with each other and with the ongoing frame.

**2. `ERR_CHANNEL_BUSY` was unknown to the host.** With firmware auto-CAD enabled (`CMD_SET_AUTO_CAD`), the pymc_usb modem refuses a busy TX with `ERR_CHANNEL_BUSY (0x0E)` *instead of trampling a neighbour* — deliberate LBT feedback. But the code was never added to `protocol_constants.py`: the `CMD_ERROR` dispatch woke the TX waiter with `None` and `send()` reported a generic `"TX failed — no TX_DONE response"`. The modem's polite refusal became a dropped packet.

## Change

- **Time-bounded LBT** on both drivers (`lbt_max_wait_seconds`, **default 4 s to match MeshCore's `getCADFailMaxDuration()`**; `lbt_retry_interval_ms`, default 200 ms ± 50 % jitter), mirroring the SPI rework and the MeshCore dispatcher. `lbt_max_attempts` stays accepted for call-site compatibility (the repeater's `get_radio_for_board` passes it) but no longer drives the loop.
- **`ERR_CHANNEL_BUSY` defined and handled**: the dispatch records the last modem error code; `send()` retries a busy refusal with the same jittered delays, drawing from the **same time budget** as the host-side CAD loop. Past the budget it reports failure *without forcing* — unlike the SPI path there is nothing wedged to push through, the modem is alive and answering.
- `send()` metadata shape unchanged (`lbt_attempts` / `lbt_backoff_delays_ms` cover host-side waits and modem refusals alike) — LBT diagnostics keep working.

Independent of #116 (disjoint files); the two merge in any order. Firmware-side counterpart (reception guard + CAD before `standby()` in `CMD_TX_REQUEST`) follows in openhop_modem.

## Test plan

- [x] `pytest tests/test_modem_lbt.py` — 12 tests: elapsed-time budgets on both drivers, in-flight CAD timeout clamping, clear-channel metadata, real `CMD_ERROR / ERR_CHANNEL_BUSY` waiter dispatch, busy-refusal retry/success, bounded refusal failure, non-busy errors, and knob clamps/defaults
- [x] 95 combined modem LBT/CAD/hardware/transport tests passed
- [x] Full pre-commit gate passed, including pytest
- [x] Synced with current `dev` while preserving serialized commands and consolidated CAD restoration
- [x] Live dual-modem host: both firmware-#58 modems connected/configured, CAD settings acknowledged, and a clear-channel advert transmitted successfully
- [ ] Live contention path: observe `ERR_CHANNEL_BUSY` retry/refusal while sustained neighbouring traffic keeps the channel occupied
