### PR TITLE
feat(rf_fabric): origin_tx knob to fan locally originated packets out to all radios

### DIFF
--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -1135,6 +1135,29 @@ class Dispatcher:
                 continue
         return None
 
+    def _origin_fanout_fabric(self, packet: Packet, radio_id: Optional[str]) -> Optional[Any]:
+        """Return the fabric when this TX should fan out to every radio.
+
+        Fan-out applies only to locally originated packets — forwards carry
+        ``_rx_radio_id`` stamped on RX — and only when the caller did not
+        request an explicit ``radio_id``, the fabric opted in with
+        ``origin_tx="all"``, and more than one radio is registered.
+        """
+        if radio_id is not None:
+            return None
+        if getattr(packet, "_rx_radio_id", None) is not None:
+            return None
+        fabric = getattr(self.radio, "fabric", None)
+        if fabric is None and hasattr(self.radio, "send_all"):
+            fabric = self.radio  # RFFabric (or compatible) used directly
+        if fabric is None or not hasattr(fabric, "send_all"):
+            return None
+        if getattr(fabric, "origin_tx", "default") != "all":
+            return None
+        if len(getattr(fabric, "radios", {})) < 2:
+            return None
+        return fabric
+
     async def _transmit_locked(
         self,
         packet: Packet,
@@ -1167,19 +1190,31 @@ class Dispatcher:
         self.state = DispatcherState.TRANSMIT
         raw = packet.write_to()
         tx_metadata = None
+        # Locally originated packets optionally egress on every fabric radio
+        # (fabric.origin_tx="all"): tx_mode=bridge only steers *forwards*
+        # (RX radio -> the other radio), so without fan-out an origin leaves
+        # on the default radio only and never crosses the link — a companion
+        # behind a bridge could be reached but never speak.
+        fanout_fabric = self._origin_fanout_fabric(packet, radio_id)
         # Resolve which fabric/radio endpoint will TX for log clarity (multi-radio).
-        tx_radio_id = self._resolve_tx_radio_id_for_log(raw, radio_id)
+        if fanout_fabric is not None:
+            tx_radio_id = "all"
+        else:
+            tx_radio_id = self._resolve_tx_radio_id_for_log(raw, radio_id)
         try:
-            # Prefer fabric/radio multi-radio send(data, radio_id=...) when
-            # available; fall back to the legacy single-arg send(raw).
-            send_fn = self.radio.send
-            if radio_id is not None:
-                try:
-                    tx_metadata = await send_fn(raw, radio_id=radio_id)
-                except TypeError:
-                    tx_metadata = await send_fn(raw)
+            if fanout_fabric is not None:
+                tx_metadata = await fanout_fabric.send_all(raw)
             else:
-                tx_metadata = await send_fn(raw)
+                # Prefer fabric/radio multi-radio send(data, radio_id=...) when
+                # available; fall back to the legacy single-arg send(raw).
+                send_fn = self.radio.send
+                if radio_id is not None:
+                    try:
+                        tx_metadata = await send_fn(raw, radio_id=radio_id)
+                    except TypeError:
+                        tx_metadata = await send_fn(raw)
+                else:
+                    tx_metadata = await send_fn(raw)
         except Exception as e:
             radio_label = f" radio={tx_radio_id}" if tx_radio_id else ""
             self._log(f"Radio transmit error{radio_label}: {e}")

--- a/src/openhop_core/rf_fabric/fabric.py
+++ b/src/openhop_core/rf_fabric/fabric.py
@@ -29,6 +29,7 @@ class RFFabric:
         self._ingress_callback: Optional[Callable[[RFIngress], Any]] = None
         self._legacy_rx_callback: Optional[LegacyRxCallback] = None
         self._tx_selector: Optional[TxSelector] = None
+        self._origin_tx: str = "default"
         self._armed = False
         # Latest delivered reception metrics (for FabricRadio get_last_*).
         self._last_rssi: int = 0
@@ -122,6 +123,27 @@ class RFFabric:
     def set_tx_selector(self, selector: Optional[TxSelector]) -> None:
         """Optional policy: ``selector(data) -> radio_id | None`` for default TX."""
         self._tx_selector = selector
+
+    @property
+    def origin_tx(self) -> str:
+        """Egress policy for locally originated packets: "default" or "all"."""
+        return self._origin_tx
+
+    def set_origin_tx(self, mode: str) -> None:
+        """Set the egress policy for locally originated packets.
+
+        - "default": origins TX on the default/selector radio (current
+          behaviour, and the default).
+        - "all": origins fan out to every registered radio via
+          :meth:`send_all`. Bridge topologies need this: ``tx_mode=bridge``
+          only steers *forwards* (RX radio -> the other radio); an origin
+          packet has no RX side, so without fan-out it leaves on a single
+          radio and never crosses the link.
+        """
+        mode_l = (mode or "default").strip().lower()
+        if mode_l not in ("default", "all"):
+            raise ValueError(f"Unknown origin_tx mode={mode!r}. Supported: default, all")
+        self._origin_tx = mode_l
 
     # ------------------------------------------------------------------
     # Callbacks / arming
@@ -281,6 +303,43 @@ class RFFabric:
             return {"ok": True, "radio_id": rid}
         # Unknown non-dict success payload: leave unchanged.
         return result
+
+    async def send_all(self, data: bytes) -> Any:
+        """Transmit ``data`` on every registered radio, sequentially.
+
+        Radios TX in registration order and each ``send()`` is awaited to
+        completion before the next starts, so transmissions are serialised —
+        a driver that returns on TX-done naturally staggers the next radio by
+        its own airtime. Register the real RF radio first so a slow or hung
+        link radio never delays RF egress.
+
+        Per-radio failures are logged and skipped; the call fails (returns
+        ``None``) only when every radio failed. On success returns the first
+        successful radio's metadata dict with ``radio_id`` set to ``"all"``
+        and the successful ids listed under ``radio_ids`` (non-dict legacy
+        results are wrapped).
+        """
+        if not self._radios:
+            raise RuntimeError("RFFabric has no registered radio")
+        first_meta: Optional[dict] = None
+        ok_ids = []
+        for rid in list(self._radios.keys()):
+            try:
+                result = await self.send(data, radio_id=rid)
+            except Exception as exc:
+                logger.warning("send_all: TX failed on radio_id=%s: %s", rid, exc)
+                continue
+            if result is None or result is False:
+                logger.warning("send_all: no TX confirmation from radio_id=%s", rid)
+                continue
+            ok_ids.append(rid)
+            if first_meta is None:
+                first_meta = dict(result) if isinstance(result, dict) else {"ok": True}
+        if first_meta is None:
+            return None
+        first_meta["radio_id"] = "all"
+        first_meta["radio_ids"] = ok_ids
+        return first_meta
 
     def get_last_rssi(self) -> int:
         if self._last_rx_radio_id and self._last_rx_radio_id in self._radios:

--- a/tests/test_rf_fabric_origin_tx.py
+++ b/tests/test_rf_fabric_origin_tx.py
@@ -1,0 +1,195 @@
+"""fabric.origin_tx="all": locally originated packets egress on every radio.
+
+Forwards are steered by tx_mode (e.g. bridge: RX radio -> the other radio),
+but a locally originated packet has no RX side, so in a bridge topology it
+would leave on the default radio only and never cross the link. With
+origin_tx="all" the Dispatcher fans origins out to every registered radio,
+sequentially in registration order (send_all awaits each radio's TX-done
+before the next starts, so transmissions are serialised, never simultaneous).
+"""
+
+from __future__ import annotations
+
+import pytest
+from openhop_core.node.dispatcher import Dispatcher
+from openhop_core.protocol import Packet
+from openhop_core.protocol.constants import PAYLOAD_TYPE_ADVERT
+from openhop_core.protocol.packet_filter import PacketFilter
+from openhop_core.rf_fabric import FabricRadio, RFFabric
+
+
+class _MockRadio:
+    def __init__(self, name: str = "r", order_log=None):
+        self.name = name
+        self.rx_callback = None
+        self.sent = []
+        self._order_log = order_log
+
+    def set_rx_callback(self, callback):
+        self.rx_callback = callback
+
+    async def send(self, data: bytes):
+        self.sent.append(data)
+        if self._order_log is not None:
+            self._order_log.append(self.name)
+        return {"radio": self.name}
+
+    def get_last_rssi(self):
+        return -80
+
+    def get_last_snr(self):
+        return 7.5
+
+
+class _FailingRadio(_MockRadio):
+    async def send(self, data: bytes):
+        raise RuntimeError("TX path down")
+
+
+class _NoConfirmRadio(_MockRadio):
+    async def send(self, data: bytes):
+        self.sent.append(data)
+        return None
+
+
+def _origin_advert() -> Packet:
+    pkt = Packet()
+    pkt.header = PAYLOAD_TYPE_ADVERT << 2
+    pkt.payload = bytearray(b"origin-tx")
+    pkt.payload_len = len(pkt.payload)
+    pkt.path_len = 0
+    return pkt
+
+
+class TestOriginTxKnob:
+    def test_default_and_validation(self):
+        fabric = RFFabric()
+        assert fabric.origin_tx == "default"
+        fabric.set_origin_tx("all")
+        assert fabric.origin_tx == "all"
+        fabric.set_origin_tx(" Default ")
+        assert fabric.origin_tx == "default"
+        with pytest.raises(ValueError):
+            fabric.set_origin_tx("broadcast")
+
+
+class TestSendAll:
+    @pytest.mark.asyncio
+    async def test_sequential_fan_out_in_registration_order(self):
+        order = []
+        a = _MockRadio("a", order_log=order)
+        b = _MockRadio("b", order_log=order)
+        fabric = RFFabric()
+        fabric.register_radio(a, radio_id="ra")
+        fabric.register_radio(b, radio_id="rb")
+
+        meta = await fabric.send_all(b"fan-out")
+
+        assert a.sent == [b"fan-out"]
+        assert b.sent == [b"fan-out"]
+        assert order == ["a", "b"]
+        # First success supplies the metadata; fan-out is marked explicitly.
+        assert meta["radio"] == "a"
+        assert meta["radio_id"] == "all"
+        assert meta["radio_ids"] == ["ra", "rb"]
+
+    @pytest.mark.asyncio
+    async def test_one_radio_failing_does_not_block_the_rest(self):
+        a = _FailingRadio("a")
+        b = _MockRadio("b")
+        fabric = RFFabric()
+        fabric.register_radio(a, radio_id="ra")
+        fabric.register_radio(b, radio_id="rb")
+
+        meta = await fabric.send_all(b"survivor")
+
+        assert b.sent == [b"survivor"]
+        assert meta["radio"] == "b"
+        assert meta["radio_id"] == "all"
+        assert meta["radio_ids"] == ["rb"]
+
+    @pytest.mark.asyncio
+    async def test_all_radios_failing_reports_tx_failure(self):
+        fabric = RFFabric()
+        fabric.register_radio(_FailingRadio("a"), radio_id="ra")
+        fabric.register_radio(_NoConfirmRadio("b"), radio_id="rb")
+
+        assert await fabric.send_all(b"nope") is None
+
+
+class TestDispatcherOriginFanOut:
+    @pytest.mark.asyncio
+    async def test_origin_fans_out_to_every_radio(self):
+        a = _MockRadio("a")
+        b = _MockRadio("b")
+        fr = FabricRadio(radios=[(a, "ra"), (b, "rb")], default_radio_id="ra")
+        fr.fabric.set_origin_tx("all")
+        d = Dispatcher(radio=fr, packet_filter=PacketFilter())
+
+        pkt = _origin_advert()
+        ok = await d.send_packet(pkt, wait_for_ack=False)
+
+        assert ok is True
+        raw = pkt.write_to()
+        assert a.sent == [raw]
+        assert b.sent == [raw]
+        assert pkt._tx_metadata["radio_id"] == "all"
+        assert pkt._tx_metadata["radio_ids"] == ["ra", "rb"]
+
+    @pytest.mark.asyncio
+    async def test_forwarded_packet_does_not_fan_out(self):
+        a = _MockRadio("a")
+        b = _MockRadio("b")
+        fr = FabricRadio(radios=[(a, "ra"), (b, "rb")], default_radio_id="ra")
+        fr.fabric.set_origin_tx("all")
+        d = Dispatcher(radio=fr, packet_filter=PacketFilter())
+
+        pkt = _origin_advert()
+        pkt._rx_radio_id = "ra"  # forwards are stamped on RX
+        ok = await d.send_packet(pkt, wait_for_ack=False)
+
+        assert ok is True
+        assert a.sent == [pkt.write_to()]
+        assert b.sent == []
+
+    @pytest.mark.asyncio
+    async def test_explicit_radio_id_wins_over_fan_out(self):
+        a = _MockRadio("a")
+        b = _MockRadio("b")
+        fr = FabricRadio(radios=[(a, "ra"), (b, "rb")], default_radio_id="ra")
+        fr.fabric.set_origin_tx("all")
+        d = Dispatcher(radio=fr, packet_filter=PacketFilter())
+
+        pkt = _origin_advert()
+        ok = await d.send_packet(pkt, wait_for_ack=False, radio_id="rb")
+
+        assert ok is True
+        assert a.sent == []
+        assert b.sent == [pkt.write_to()]
+
+    @pytest.mark.asyncio
+    async def test_origin_tx_default_keeps_single_radio_egress(self):
+        a = _MockRadio("a")
+        b = _MockRadio("b")
+        fr = FabricRadio(radios=[(a, "ra"), (b, "rb")], default_radio_id="ra")
+        d = Dispatcher(radio=fr, packet_filter=PacketFilter())
+
+        pkt = _origin_advert()
+        ok = await d.send_packet(pkt, wait_for_ack=False)
+
+        assert ok is True
+        assert a.sent == [pkt.write_to()]
+        assert b.sent == []
+
+    @pytest.mark.asyncio
+    async def test_single_radio_fabric_ignores_fan_out(self):
+        a = _MockRadio("a")
+        fr = FabricRadio(radios=[(a, "ra")], default_radio_id="ra")
+        fr.fabric.set_origin_tx("all")
+        d = Dispatcher(radio=fr, packet_filter=PacketFilter())
+
+        pkt = _origin_advert()
+        ok = await d.send_packet(pkt, wait_for_ack=False)
+
+        assert ok is True
+        assert a.sent == [pkt.write_to()]


### PR DESCRIPTION
## What

`fabric.origin_tx: default | all` — the API shape preferred in #123. With `all`, the Dispatcher fans **locally originated** packets (own adverts, companion DMs, server replies) out to every registered radio via a new `RFFabric.send_all()`; forwards keep following `tx_mode` untouched. Default is `default` = exactly today's behaviour.

The `radio_id="*"` sentinel from the original proposal is gone — nothing new in the public `send()` API. The dispatcher decides (it is the only place that can tell an origin from a forward: forwards carry `_rx_radio_id` stamped on RX) and calls `send_all()` explicitly.

## Why

In a bridge topology (`tx_mode=bridge`) forwards are steered RX radio → the other radio, but origins leave on the default radio only — so they never cross the link: a companion behind the bridge can be reached but never speak, and the node's own adverts stay on one side.

## Serialisation (the question from #123)

`send_all()` is a plain sequential loop in registration (= config) order; each driver's `send()` holds a per-radio TX lock and returns only on `TX_DONE`, so radio N+1 starts after radio N's actual airtime — transmissions are serialised by construction, never simultaneous. Per-radio failures are logged and skipped; TX fails only when every radio failed. First success supplies the metadata dict, marked `radio_id="all"` + `radio_ids=[…]`.

## Evidence

- **Bench A/B** (two pymc_usb modems on separate frequencies + TCP link, MeshCore witness node): with `default`, origins left on `TX local` only and the link layer saw zero frames (the bug); with `all`, both sides logged `TX all`, the peer received via `RX link`, and companion→repeater **login across the bridge succeeded** with command replies. Pure forwards stayed single-radio (`RX local → TX link`, no same-air echo).
- **Production**: running on our Czech-mesh internet bridge since 2026-08-24. Observed chain: origin `TX all` → peer `RX link` (+2.0 s link delay) → `TX local` onto the far RF segment → **a mast repeater 130 km away rebroadcast it**.

## Tests / gates

10 new tests in `tests/test_rf_fabric_origin_tx.py` (knob validation, fan-out order, failure isolation, dispatcher origin/forward/explicit-radio_id/single-radio paths). Full suite green locally; black 26.5.1 / isort 5.12.0 / flake8 7.1.1 clean.

Companion PR (config plumbing): openhop-dev/openhop_repeater — linked below. Closes the proposal in #123 if accepted.
