### PR TITLE
fix: initialize asyncio primitives on owning loops

### DIFF
--- a/src/openhop_core/companion/base_support.py
+++ b/src/openhop_core/companion/base_support.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 from collections import OrderedDict
 from typing import Any, Optional
@@ -91,7 +92,7 @@ class ResponseWaiter:
     """Helper for awaiting async protocol/login responses."""
 
     def __init__(self) -> None:
-        self.event = asyncio.Event()
+        self.event = threading.Event()
         self.data: dict = {"success": False, "text": None, "parsed": {}}
 
     def callback(
@@ -106,11 +107,10 @@ class ResponseWaiter:
         self.event.set()
 
     async def wait(self, timeout: float = 10.0) -> dict:
-        try:
-            await asyncio.wait_for(self.event.wait(), timeout=timeout)
+        completed = await asyncio.to_thread(self.event.wait, timeout)
+        if completed:
             return self.data
-        except asyncio.TimeoutError:
-            return {**self.data, "timeout": True}
+        return {**self.data, "timeout": True}
 
 
 class _SeenCache:

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -166,8 +166,8 @@ class SX1262Radio(LoRaRadio):
         self.last_snr: float = 0.0
         self.last_signal_rssi: int = -99
         self._initialized = False
-        self._rx_lock = asyncio.Lock()
-        self._tx_lock = asyncio.Lock()
+        self._rx_lock: Optional[asyncio.Lock] = None
+        self._tx_lock: Optional[asyncio.Lock] = None
 
         # GPIO management: prefer an explicitly provided manager (multi-CH341),
         # else a process-default external adapter manager, else a private
@@ -207,9 +207,9 @@ class SX1262Radio(LoRaRadio):
         self._rxled_pin_setup = False
         self._en_pins_setup = False
 
-        self._tx_done_event = asyncio.Event()
-        self._rx_done_event = asyncio.Event()
-        self._cad_event = asyncio.Event()
+        self._tx_done_event: Optional[asyncio.Event] = None
+        self._rx_done_event: Optional[asyncio.Event] = None
+        self._cad_event: Optional[asyncio.Event] = None
         self._pending_rx_irq_status = 0
 
         # Store last IRQ status for background task
@@ -269,6 +269,34 @@ class SX1262Radio(LoRaRadio):
 
         # RX callback for received packets
         self.rx_callback = None
+
+    def _get_rx_lock(self) -> asyncio.Lock:
+        if self._rx_lock is None:
+            self._rx_lock = asyncio.Lock()
+        return self._rx_lock
+
+    def _get_tx_lock(self) -> asyncio.Lock:
+        if self._tx_lock is None:
+            self._tx_lock = asyncio.Lock()
+        return self._tx_lock
+
+    def _tx_locked(self) -> bool:
+        return self._tx_lock is not None and self._tx_lock.locked()
+
+    def _get_tx_done_event(self) -> asyncio.Event:
+        if self._tx_done_event is None:
+            self._tx_done_event = asyncio.Event()
+        return self._tx_done_event
+
+    def _get_rx_done_event(self) -> asyncio.Event:
+        if self._rx_done_event is None:
+            self._rx_done_event = asyncio.Event()
+        return self._rx_done_event
+
+    def _get_cad_event(self) -> asyncio.Event:
+        if self._cad_event is None:
+            self._cad_event = asyncio.Event()
+        return self._cad_event
 
     @staticmethod
     def _normalize_en_pins(en_pin: int = -1, en_pins: Optional[list[int]] = None) -> list[int]:
@@ -398,7 +426,8 @@ class SX1262Radio(LoRaRadio):
                 self._last_irq_status = irqStat
             if irqStat & self.lora.IRQ_TX_DONE:
                 _trace("[TX] TX_DONE interrupt (0x{:04X})".format(self.lora.IRQ_TX_DONE))
-                self._tx_done_event.set()
+                if self._tx_done_event is not None:
+                    self._tx_done_event.set()
 
             if irqStat & (self.lora.IRQ_CAD_DETECTED | self.lora.IRQ_CAD_DONE):
                 cad_detected = bool(irqStat & self.lora.IRQ_CAD_DETECTED)
@@ -409,7 +438,7 @@ class SX1262Radio(LoRaRadio):
 
                 self._last_cad_detected = cad_detected
                 self._last_cad_irq_status = irqStat
-                if hasattr(self, "_cad_event"):
+                if self._cad_event is not None:
                     self._cad_event.set()
 
             rx_interrupts = self._get_rx_irq_mask()
@@ -475,8 +504,9 @@ class SX1262Radio(LoRaRadio):
                 # Only wake the background task for TERMINAL interrupts
                 # Intermediate interrupts (preamble, sync, header valid) are just progress updates
                 if irqStat & terminal_interrupts:
-                    if not self._tx_lock.locked():
-                        self._rx_done_event.set()
+                    if not self._tx_locked():
+                        if self._rx_done_event is not None:
+                            self._rx_done_event.set()
                         _trace(f"[RX] Terminal interrupt 0x{irqStat:04X} - waking background task")
                     else:
                         logger.debug(
@@ -488,8 +518,9 @@ class SX1262Radio(LoRaRadio):
 
         except Exception as e:
             logger.error(f"IRQ handler error: {e}")
-            self._tx_done_event.set()
-            if not self._tx_lock.locked():
+            if self._tx_done_event is not None:
+                self._tx_done_event.set()
+            if not self._tx_locked() and self._rx_done_event is not None:
                 self._rx_done_event.set()
 
     async def _drain_pending_rx_irq_before_buffer_reuse(self) -> None:
@@ -498,7 +529,7 @@ class SX1262Radio(LoRaRadio):
             return
 
         callback_packet_data = None
-        async with self._rx_lock:
+        async with self._get_rx_lock():
             pending_irq = self._pending_rx_irq_status
             if not pending_irq:
                 return
@@ -566,10 +597,11 @@ class SX1262Radio(LoRaRadio):
                 if self._interrupt_setup:
                     # Wait for RX_DONE event
                     try:
+                        rx_done_event = self._get_rx_done_event()
                         await asyncio.wait_for(
-                            self._rx_done_event.wait(), timeout=self.RADIO_TIMING_DELAY
+                            rx_done_event.wait(), timeout=self.RADIO_TIMING_DELAY
                         )
-                        self._rx_done_event.clear()
+                        rx_done_event.clear()
                         _trace("[RX] RX_DONE event triggered!")
 
                         # Mark that we're processing a packet (prevents noise floor sampling)
@@ -578,7 +610,7 @@ class SX1262Radio(LoRaRadio):
 
                         callback_packet_data = None
                         try:
-                            async with self._rx_lock:
+                            async with self._get_rx_lock():
                                 # Use the IRQ status stored by the interrupt handler
                                 irqStat = self._last_irq_status
 
@@ -694,7 +726,7 @@ class SX1262Radio(LoRaRadio):
                                 else:
                                     logger.debug(f"[RX] Other interrupt: 0x{irqStat:04X}")
 
-                                if not self._tx_lock.locked():
+                                if not self._tx_locked():
                                     try:
                                         self.lora.request(self.lora.RX_CONTINUOUS)
                                         self.lora.clearIrqStatus(0xFFFF)
@@ -1134,8 +1166,10 @@ class SX1262Radio(LoRaRadio):
     # ERROR. TRACE carries the chip-level minutiae.
     async def _prepare_radio_for_tx(self) -> tuple[bool, list[int]]:
         """Prepare radio hardware for transmission. Returns (success, lbt_backoff_delays_ms)."""
-        self._tx_done_event.clear()
-        self._rx_done_event.clear()
+        tx_done_event = self._get_tx_done_event()
+        rx_done_event = self._get_rx_done_event()
+        tx_done_event.clear()
+        rx_done_event.clear()
 
         # Drain any packet-bearing RX IRQ that fired while TX was active and was
         # latched in software before we begin CAD/TX buffer reuse.
@@ -1360,7 +1394,7 @@ class SX1262Radio(LoRaRadio):
                 wait_for = 0.0
 
             try:
-                await asyncio.wait_for(self._tx_done_event.wait(), timeout=wait_for)
+                await asyncio.wait_for(self._get_tx_done_event().wait(), timeout=wait_for)
                 _trace("[TX] TX completion interrupt received!")
                 return True
             except asyncio.TimeoutError:
@@ -1492,7 +1526,7 @@ class SX1262Radio(LoRaRadio):
         if not self._initialized or self.lora is None:
             raise RuntimeError("Radio not initialized")
 
-        async with self._tx_lock:
+        async with self._get_tx_lock():
             try:
                 data_list = list(data)
                 length = len(data_list)
@@ -1587,7 +1621,7 @@ class SX1262Radio(LoRaRadio):
             return
 
         # Don't sample during TX operations.
-        if self._tx_lock.locked():
+        if self._tx_locked():
             return
 
         # Don't sample if packet processing is active or RX terminal IRQs are pending.
@@ -1651,7 +1685,7 @@ class SX1262Radio(LoRaRadio):
             return None
 
         # Unavailable while TX is active; callers should treat None as "no sample".
-        if hasattr(self, "_tx_lock") and self._tx_lock.locked():
+        if hasattr(self, "_tx_lock") and self._tx_locked():
             return None
 
         # No accepted background sample yet; internal -120.0 is a reset sentinel.
@@ -1727,7 +1761,7 @@ class SX1262Radio(LoRaRadio):
         ldro = sf >= 11 and bw <= 125000
 
         deadline = time.monotonic() + 10.0
-        while self._tx_lock.locked():
+        while self._tx_locked():
             if time.monotonic() > deadline:
                 logger.error("configure_radio: TX did not complete within 10s")
                 return False
@@ -1939,7 +1973,7 @@ class SX1262Radio(LoRaRadio):
             if respect_tx_lock:
                 try:
                     await asyncio.wait_for(
-                        self._tx_lock.acquire(),
+                        self._get_tx_lock().acquire(),
                         timeout=max(0.1, float(timeout) + 0.25),
                     )
                     acquired_tx_lock = True
@@ -1989,7 +2023,8 @@ class SX1262Radio(LoRaRadio):
                 logger.warning("[CAD] IRQ pin stuck HIGH, proceeding anyway")
 
             # Step 3: Clear the CAD event before configuring
-            self._cad_event.clear()
+            cad_event = self._get_cad_event()
+            cad_event.clear()
 
             # Step 4: Configure CAD interrupts
             cad_mask = self.lora.IRQ_CAD_DONE | self.lora.IRQ_CAD_DETECTED
@@ -2031,8 +2066,8 @@ class SX1262Radio(LoRaRadio):
             )
 
             try:
-                await asyncio.wait_for(self._cad_event.wait(), timeout=timeout)
-                self._cad_event.clear()
+                await asyncio.wait_for(cad_event.wait(), timeout=timeout)
+                cad_event.clear()
 
                 # Use CAD results stored by interrupt handler (avoids race condition)
                 irq = self._last_cad_irq_status
@@ -2127,7 +2162,7 @@ class SX1262Radio(LoRaRadio):
                 rx_mask = self._get_rx_irq_mask()
                 self.lora.setDioIrqParams(rx_mask, rx_mask, self.lora.IRQ_NONE, self.lora.IRQ_NONE)
                 await asyncio.sleep(0.001)
-                if acquired_tx_lock or not self._tx_lock.locked():
+                if acquired_tx_lock or not self._tx_locked():
                     self.lora.request(self.lora.RX_CONTINUOUS)
                     await asyncio.sleep(
                         self.RADIO_TIMING_DELAY
@@ -2144,8 +2179,8 @@ class SX1262Radio(LoRaRadio):
             except Exception as e:
                 logger.warning(f"[CAD] Failed to restore RX mode: {e}")
             finally:
-                if acquired_tx_lock and self._tx_lock.locked():
-                    self._tx_lock.release()
+                if acquired_tx_lock and self._tx_locked():
+                    self._get_tx_lock().release()
 
     def _bind_instance_spi_transport(self) -> None:
         """Attach a per-instance SPI transport when possible.

--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -146,7 +146,7 @@ class TCPLoRaRadio(_RadioBase):
         # Serialize command/response transactions. Multiple callers can wait
         # for the same response command (notably consecutive CAD updates), and
         # the response-event map supports only one waiter per command byte.
-        self._command_lock = asyncio.Lock()
+        self._command_lock: Optional[asyncio.Lock] = None
 
         # Custom CAD thresholds. Set lazily by set_custom_cad_thresholds()
         # or perform_cad(det_peak=..., det_min=...); read by _reopen_socket
@@ -171,7 +171,7 @@ class TCPLoRaRadio(_RadioBase):
         self._response_lock = threading.Lock()
 
         # TX lock
-        self._tx_lock = asyncio.Lock()
+        self._tx_lock: Optional[asyncio.Lock] = None
 
         # Stats
         self._tx_count = 0
@@ -186,6 +186,16 @@ class TCPLoRaRadio(_RadioBase):
             f"bw={bandwidth / 1000:.0f}kHz, power={tx_power}dBm, "
             f"syncword=0x{sync_word:04X}"
         )
+
+    def _get_tx_lock(self) -> asyncio.Lock:
+        if self._tx_lock is None:
+            self._tx_lock = asyncio.Lock()
+        return self._tx_lock
+
+    def _get_command_lock(self) -> asyncio.Lock:
+        if self._command_lock is None:
+            self._command_lock = asyncio.Lock()
+        return self._command_lock
 
     # ══════════════════════════════════════════════════════════
     # LoRaRadio interface
@@ -258,7 +268,7 @@ class TCPLoRaRadio(_RadioBase):
             logger.error("Radio not initialized")
             return None
 
-        async with self._tx_lock:
+        async with self._get_tx_lock():
             lbt_backoff_delays: list[float] = []
 
             if self.lbt_enabled:
@@ -442,7 +452,7 @@ class TCPLoRaRadio(_RadioBase):
     def get_noise_floor(self) -> Optional[float]:
         if not self._initialized:
             return None
-        if self._tx_lock.locked():
+        if self._tx_lock is not None and self._tx_lock.locked():
             return None
         return self._noise_floor
 
@@ -913,7 +923,7 @@ class TCPLoRaRadio(_RadioBase):
         expect_cmd: int,
         timeout: float = 5.0,
     ) -> Optional[bytes]:
-        async with self._command_lock:
+        async with self._get_command_lock():
             if self._sock is None:
                 return None
 

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -167,7 +167,7 @@ class USBLoRaRadio(_RadioBase):
         # CAD thresholds and symbol count back-to-back, and both commands wait
         # for CMD_CAD_PARAMS_RESP. Without serialization the second waiter
         # replaces the first entry in _response_events and one update times out.
-        self._command_lock = asyncio.Lock()
+        self._command_lock: Optional[asyncio.Lock] = None
 
         # Custom CAD thresholds. Set lazily by set_custom_cad_thresholds()
         # or perform_cad(det_peak=..., det_min=...); kept in attributes from
@@ -178,7 +178,7 @@ class USBLoRaRadio(_RadioBase):
         self._custom_cad_symbol_num: Optional[int] = None
 
         # TX lock to serialize transmissions (matches SX1262Radio)
-        self._tx_lock = asyncio.Lock()
+        self._tx_lock: Optional[asyncio.Lock] = None
 
         # Stats
         self._tx_count = 0
@@ -191,6 +191,16 @@ class USBLoRaRadio(_RadioBase):
             f"sf={spreading_factor}, bw={bandwidth / 1000:.0f}kHz, "
             f"power={tx_power}dBm, syncword=0x{sync_word:04X}"
         )
+
+    def _get_tx_lock(self) -> asyncio.Lock:
+        if self._tx_lock is None:
+            self._tx_lock = asyncio.Lock()
+        return self._tx_lock
+
+    def _get_command_lock(self) -> asyncio.Lock:
+        if self._command_lock is None:
+            self._command_lock = asyncio.Lock()
+        return self._command_lock
 
     # ══════════════════════════════════════════════════════════
     # LoRaRadio interface implementation
@@ -265,7 +275,7 @@ class USBLoRaRadio(_RadioBase):
             logger.error("Radio not initialized")
             return None
 
-        async with self._tx_lock:
+        async with self._get_tx_lock():
             lbt_backoff_delays: list[float] = []
 
             # ── Listen Before Talk (CAD) ─────────────────────
@@ -483,7 +493,7 @@ class USBLoRaRadio(_RadioBase):
         """
         if not self._initialized:
             return None
-        if self._tx_lock.locked():
+        if self._tx_lock is not None and self._tx_lock.locked():
             return None
         return self._noise_floor
 
@@ -1064,7 +1074,7 @@ class USBLoRaRadio(_RadioBase):
         timeout: float = 5.0,
     ) -> Optional[bytes]:
         """Send a command frame and wait for a specific response frame."""
-        async with self._command_lock:
+        async with self._get_command_lock():
             if not self._connected_event.is_set() or not self._serial or not self._serial.is_open:
                 return None
 

--- a/src/openhop_core/hardware/wsradio.py
+++ b/src/openhop_core/hardware/wsradio.py
@@ -20,8 +20,8 @@ class WsRadio(LoRaRadio):
         self._connected = False
         self._last_tx_data = None  # Stores last transmitted packet
         self._last_tx_time = 0.0
-        self._connection_lock = asyncio.Lock()  # Prevent concurrent connection attempts
-        self._recv_lock = asyncio.Lock()  # Prevent concurrent recv calls
+        self._connection_lock = None  # Created on the running loop when first used
+        self._recv_lock = None  # Created on the running loop when first used
         self._reconnect_delay = 1.0  # Start with 1 second
         self._max_reconnect_delay = 30.0  # Max 30 seconds
         self._timeout = timeout
@@ -35,6 +35,16 @@ class WsRadio(LoRaRadio):
                 f"sf={radio_config.spreading_factor}, cr={radio_config.coding_rate}, "
                 f"preamble={radio_config.preamble_length}"
             )
+
+    def _get_connection_lock(self) -> asyncio.Lock:
+        if self._connection_lock is None:
+            self._connection_lock = asyncio.Lock()
+        return self._connection_lock
+
+    def _get_recv_lock(self) -> asyncio.Lock:
+        if self._recv_lock is None:
+            self._recv_lock = asyncio.Lock()
+        return self._recv_lock
 
     async def _send_radio_config(self):
         """Send radio configuration to the WebSocket radio."""
@@ -68,7 +78,7 @@ class WsRadio(LoRaRadio):
             logger.error(f"Failed to send radio config: {e}")
 
     async def _connect(self):
-        async with self._connection_lock:  # Prevent concurrent connection attempts
+        async with self._get_connection_lock():  # Prevent concurrent connection attempts
             if self._connected and self.ws is not None:
                 return  # Already connected
 
@@ -135,7 +145,7 @@ class WsRadio(LoRaRadio):
 
     async def wait_for_rx(self) -> bytes:
         await self._ensure()
-        async with self._recv_lock:  # Prevent concurrent recv calls
+        async with self._get_recv_lock():  # Prevent concurrent recv calls
             while True:
                 try:
                     if self.ws is None:

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -193,7 +193,7 @@ class Dispatcher:
         self.dedupe_enabled = dedupe_enabled
 
         # Simple TX lock to prevent concurrent transmissions
-        self._tx_lock = asyncio.Lock()
+        self._tx_lock: Optional[asyncio.Lock] = None
 
         # Use provided packet filter or create default
         if packet_filter is not None:
@@ -220,6 +220,12 @@ class Dispatcher:
 
         # Hook up the radio's receive callback - all radios should support this
         self._arm_rx()
+
+    def _get_tx_lock(self) -> asyncio.Lock:
+        """Create the TX lock on the running event loop when first used."""
+        if self._tx_lock is None:
+            self._tx_lock = asyncio.Lock()
+        return self._tx_lock
 
     def _ensure_lifecycle_events(self) -> tuple:
         """Create stop/stopped events on the running loop if needed."""
@@ -1036,7 +1042,7 @@ class Dispatcher:
         # Airtime duty-cycle budget: only while client-repeat is on. When
         # disabled the send path is unchanged (a recorded deliberate deferral).
         if not self._client_repeat_enabled:
-            async with self._tx_lock:  # Wait our turn
+            async with self._get_tx_lock():  # Wait our turn
                 tx_ok, ack_event, ack_crc = await self._transmit_locked(
                     packet, wait_for_ack, expected_crc, radio_id=radio_id
                 )
@@ -1051,7 +1057,7 @@ class Dispatcher:
             # sleep under the lock -- fall out of the async with to wait again.
             while True:
                 await self._await_tx_budget(packet)
-                async with self._tx_lock:  # Wait our turn
+                async with self._get_tx_lock():  # Wait our turn
                     if not self._client_repeat_enabled or self._tx_budget_wait_s() <= 0.0:
                         tx_ok, ack_event, ack_crc = await self._transmit_locked(
                             packet, wait_for_ack, expected_crc, radio_id=radio_id
@@ -1525,7 +1531,7 @@ class Dispatcher:
     def get_filter_stats(self) -> dict:
         """Get current packet filter statistics."""
         stats = self.packet_filter.get_stats()
-        stats["tx_lock_locked"] = self._tx_lock.locked()
+        stats["tx_lock_locked"] = self._tx_lock is not None and self._tx_lock.locked()
         return stats
 
     def clear_packet_filter(self) -> None:

--- a/tests/test_async_construction.py
+++ b/tests/test_async_construction.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import pytest
+
+from openhop_core.companion.base_support import ResponseWaiter
+from openhop_core.hardware.tcp_radio import TCPLoRaRadio
+from openhop_core.hardware.usb_radio import USBLoRaRadio
+from openhop_core.node.dispatcher import Dispatcher
+
+
+class _Radio:
+    def set_rx_callback(self, callback):
+        self.callback = callback
+
+    async def send(self, data):
+        del data
+        return {"airtime_ms": 0.0}
+
+
+def test_async_owners_construct_without_creating_loop_bound_primitives():
+    dispatcher = Dispatcher(_Radio())
+    tcp = TCPLoRaRadio("127.0.0.1")
+    usb = USBLoRaRadio("/dev/null")
+    waiter = ResponseWaiter()
+
+    assert dispatcher._tx_lock is None
+    assert tcp._tx_lock is None
+    assert tcp._command_lock is None
+    assert usb._tx_lock is None
+    assert usb._command_lock is None
+    assert waiter.event.is_set() is False
+
+
+@pytest.mark.asyncio
+async def test_async_owners_create_standard_primitives_on_running_loop():
+    dispatcher = Dispatcher(_Radio())
+    tcp = TCPLoRaRadio("127.0.0.1")
+    usb = USBLoRaRadio("/dev/null")
+
+    assert isinstance(dispatcher._get_tx_lock(), asyncio.Lock)
+    assert isinstance(tcp._get_tx_lock(), asyncio.Lock)
+    assert isinstance(tcp._get_command_lock(), asyncio.Lock)
+    assert isinstance(usb._get_tx_lock(), asyncio.Lock)
+    assert isinstance(usb._get_command_lock(), asyncio.Lock)
+
+
+@pytest.mark.asyncio
+async def test_response_waiter_uses_thread_event_without_blocking_loop():
+    waiter = ResponseWaiter()
+    waiter.callback(True, "done", {"value": 1})
+
+    result = await waiter.wait(timeout=0.1)
+
+    assert result == {"success": True, "text": "done", "parsed": {"value": 1}}

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -236,6 +236,11 @@ async def radio(mock_lora, mock_gpio):
     r._interrupt_setup = True
     r._gpio_manager = mock_gpio
     r._event_loop = asyncio.get_running_loop()
+    r._get_rx_lock()
+    r._get_tx_lock()
+    r._get_tx_done_event()
+    r._get_rx_done_event()
+    r._get_cad_event()
     yield r
 
 

--- a/tests/test_tx_budget.py
+++ b/tests/test_tx_budget.py
@@ -428,7 +428,7 @@ async def test_lock_free_while_throttled_waiting():
     task = asyncio.create_task(d.send_packet(_flood_txt(), wait_for_ack=False))
     await asyncio.sleep(0.02)  # let it reach the budget sleep
     assert radio.send_count == 0
-    assert not d._tx_lock.locked()  # not holding the lock while sleeping
+    assert d._tx_lock is None or not d._tx_lock.locked()  # lock-free while sleeping
 
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -462,7 +462,7 @@ async def test_toggle_off_releases_waiter_ungated(monkeypatch):
     for _ in range(5):
         await real_sleep(0)
     assert radio.send_count == 0  # parked in the budget wait
-    assert not d._tx_lock.locked()
+    assert d._tx_lock is None or not d._tx_lock.locked()
 
     d.set_client_repeat_enabled(False)  # disable does not reset the bucket
     release.set()  # let the current sleep return; the loop re-reads the flag


### PR DESCRIPTION
## Summary

Improve Python 3.9 async compatibility while keeping primitive ownership local to each Core component:

- keep standard `asyncio.Lock` and `asyncio.Event` primitives;
- store loop-bound primitives as `None` during synchronous construction;
- create them inside the owning Dispatcher or radio class on first async use;
- use a standard `threading.Event` for `ResponseWaiter`, whose callback may be synchronous;
- initialize SX1262 test locks/events on the running test loop;
- update lock-state assertions to handle the intentionally uncreated state;
- add focused synchronous-construction and running-loop regression coverage.

## Verification

- GitHub pre-commit passed.
- GitHub tests passed on Python 3.9, 3.10, 3.11, and 3.12.
- Full Python 3.9 test suite passed locally.
- Full Python 3.12 pre-commit gate passed locally, including pytest.
- Black, isort, and flake8 passed.
- `git diff --check` passed.
