### PR TITLE
Fix noise-floor SPI race and TX packet drain

### DIFF
--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -508,6 +508,10 @@ class SX1262Radio(LoRaRadio):
                     self.crc_error_count += 1
                 elif pending_irq & self.lora.IRQ_RX_DONE:
                     payloadLengthRx, rxStartBufferPointer = self.lora.getRxBufferStatus()
+                    packet_rssi_dbm, snr_db, signal_rssi_dbm = self.lora.getSignalMetrics()
+                    self.last_rssi = int(packet_rssi_dbm)
+                    self.last_snr = snr_db
+                    self.last_signal_rssi = int(signal_rssi_dbm)
                     if payloadLengthRx > 0:
                         buffer = self.lora.readBuffer(rxStartBufferPointer, payloadLengthRx)
                         callback_packet_data = bytes(buffer)

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -250,7 +250,7 @@ class SX1262Radio(LoRaRadio):
         self._floor_sample_sum = 0.0
         self._noise_floor_samples: list[float] = []
         self._last_packet_activity = 0.0
-        self._is_receiving_packet = False
+        self._processing_rx_packet = False
         self._last_sample_check = 0.0
         self.NUM_NOISE_FLOOR_SAMPLES = 20
         self.NOISE_FLOOR_UPDATE_INTERVAL = 5.0
@@ -573,7 +573,7 @@ class SX1262Radio(LoRaRadio):
                         _trace("[RX] RX_DONE event triggered!")
 
                         # Mark that we're processing a packet (prevents noise floor sampling)
-                        self._is_receiving_packet = True
+                        self._processing_rx_packet = True
                         self._last_packet_activity = time.time()
 
                         callback_packet_data = None
@@ -725,7 +725,7 @@ class SX1262Radio(LoRaRadio):
                             logger.error(f"[IRQ RX] Error processing received packet: {e}")
                         finally:
                             # Clear packet processing flag
-                            self._is_receiving_packet = False
+                            self._processing_rx_packet = False
 
                     except asyncio.TimeoutError:
                         # No RX event within timeout - normal operation
@@ -1595,14 +1595,12 @@ class SX1262Radio(LoRaRadio):
         if self._tx_lock.locked():
             return
 
-        # Don't sample if packet processing is active or RX terminal IRQs are pending.
-        if self._is_receiving_packet:
+        # Don't sample if we're receiving or processing a packet.
+        if self.is_receiving_packet():  # still arriving
             return
-        if self._pending_rx_irq_status:
+        if self._pending_rx_irq_status:  # arrived, waiting to be handled
             return
-
-        # Skip during in-flight RX activity.
-        if self.is_receiving_packet():
+        if self._processing_rx_packet:  # being handled now
             return
 
         # Give 500ms quiet time after any packet activity

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1137,10 +1137,6 @@ class SX1262Radio(LoRaRadio):
         self._tx_done_event.clear()
         self._rx_done_event.clear()
 
-        # Drain any packet-bearing RX IRQ that fired while TX was active and was
-        # latched in software before we begin CAD/TX buffer reuse.
-        await self._drain_pending_rx_irq_before_buffer_reuse()
-
         # Listen Before Talk, bounded in TIME rather than attempts: short
         # jittered retries run for the whole budget, keeping two nodes' checks
         # decorrelated and bounding the post-clear latency to one retry
@@ -1154,6 +1150,11 @@ class SX1262Radio(LoRaRadio):
 
         while True:
             scanned = False
+            # Deliver anything already latched before it can be overwritten
+            # by a subsequent reception: the latch_defers branch below skips
+            # perform_cad's own drain, so back-to-back packets during a
+            # busy channel would otherwise only get drained once, at exit.
+            await self._drain_pending_rx_irq_before_buffer_reuse()
             try:
                 # Passive check first: a latched in-progress reception is
                 # authoritative and free — and it must be consulted BEFORE
@@ -1211,6 +1212,10 @@ class SX1262Radio(LoRaRadio):
         # a transmit clears them.)
         self._rx_activity_at = 0.0
         self._rx_header_at = 0.0
+
+        # The loop's drain already ran for this iteration before the check
+        # above; a packet completing since then won't see another one.
+        await self._drain_pending_rx_irq_before_buffer_reuse()
 
         elapsed_ms = (time.monotonic() - lbt_started) * 1000
         logger.debug(

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1596,16 +1596,8 @@ class SX1262Radio(LoRaRadio):
         if self._pending_rx_irq_status:
             return
 
-        # Skip during in-flight RX activity indicated by hardware IRQ flags.
-        rx_activity_mask = (
-            self.lora.IRQ_PREAMBLE_DETECTED
-            | self.lora.IRQ_HEADER_VALID
-            | self.lora.IRQ_RX_DONE
-            | self.lora.IRQ_CRC_ERR
-            | self.lora.IRQ_HEADER_ERR
-        )
-        irq_status = self.lora.getIrqStatus()
-        if irq_status & rx_activity_mask:
+        # Skip during in-flight RX activity.
+        if self.is_receiving_packet():
             return
 
         # Give 500ms quiet time after any packet activity

--- a/tests/test_sx1262_lbt.py
+++ b/tests/test_sx1262_lbt.py
@@ -232,6 +232,22 @@ async def test_tx_commit_delivers_a_packet_caught_during_lbt(radio):
     assert radio._pending_rx_irq_status == 0
 
 
+async def test_drain_updates_signal_metrics(radio):
+    """A packet delivered via drain must report its own RSSI/SNR, not
+    whatever was cached from the last packet the normal path handled."""
+    radio.set_rx_callback(lambda _: None)
+    radio.lora.getRxBufferStatus.return_value = (4, 0x80)
+    radio.lora.readBuffer.return_value = list(b"test")
+    radio.lora.getSignalMetrics.return_value = (-77.0, 6.5, -79.0)
+    radio._pending_rx_irq_status = IRQ_RX_DONE
+
+    await radio._drain_pending_rx_irq_before_buffer_reuse()
+
+    assert radio.last_rssi == -77
+    assert radio.last_snr == 6.5
+    assert radio.last_signal_rssi == -79
+
+
 # ─── LBT: time budget, not attempt count ─────────────────────────────
 
 

--- a/tests/test_sx1262_lbt.py
+++ b/tests/test_sx1262_lbt.py
@@ -215,6 +215,23 @@ async def test_lbt_standby_only_after_channel_clear(radio):
     assert radio.perform_cad.await_count == 1
 
 
+async def test_tx_commit_delivers_a_packet_caught_during_lbt(radio):
+    """A packet that completed on the LBT loop's last check has no pending
+    wake-up (_tx_lock is held) and no further CAD call coming to drain it:
+    the TX-commit point must deliver it itself, before staging TX."""
+    delivered = []
+    radio.set_rx_callback(delivered.append)
+    radio.lora.getRxBufferStatus.return_value = (4, 0x80)
+    radio.lora.readBuffer.return_value = list(b"test")
+    radio.perform_cad = AsyncMock(return_value=False)
+    radio._pending_rx_irq_status = IRQ_RX_DONE
+
+    await radio._prepare_radio_for_tx()
+
+    assert delivered == [b"test"]
+    assert radio._pending_rx_irq_status == 0
+
+
 # ─── LBT: time budget, not attempt count ─────────────────────────────
 
 

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -957,9 +957,9 @@ class TestRxBackgroundTask:
         assert radio.last_rssi == -85
         assert radio.last_snr == pytest.approx(7.5)
 
-    async def test_is_receiving_packet_flag_cleared_after_processing(self, radio):
+    async def test_processing_rx_packet_flag_cleared_after_processing(self, radio):
         await self._run_task_with(radio, irq_flags=IRQ_RX_DONE, callback=lambda _: None)
-        assert not radio._is_receiving_packet
+        assert not radio._processing_rx_packet
 
     async def test_crc_error_logs_diagnostic_info(self, radio, mock_lora, caplog):
         import logging
@@ -1079,7 +1079,7 @@ class TestNoiseFloorSampling:
         radio.lora.getRssiInst.assert_not_called()
 
     def test_no_sample_during_packet_reception(self, radio):
-        radio._is_receiving_packet = True
+        radio._processing_rx_packet = True
         with patch("openhop_core.hardware.sx1262_wrapper.time.time", return_value=20.0):
             radio._sample_noise_floor()
         radio.lora.getRssiInst.assert_not_called()
@@ -1114,7 +1114,7 @@ class TestNoiseFloorSampling:
     def test_sample_accepted_during_quiet_period(self, radio, mock_lora):
         mock_lora.getRssiInst.return_value = 160  # -80 dBm
         radio._last_packet_activity = 0.0
-        radio._is_receiving_packet = False
+        radio._processing_rx_packet = False
         with patch(
             "openhop_core.hardware.sx1262_wrapper.time.time", return_value=200.0
         ):
@@ -1124,7 +1124,7 @@ class TestNoiseFloorSampling:
 
     def test_rolling_window_averages_latest_20_samples(self, radio, mock_lora):
         radio._last_packet_activity = 0.0
-        radio._is_receiving_packet = False
+        radio._processing_rx_packet = False
         samples_dbm = [(-120.0 + i) for i in range(21)]
         mock_lora.getRssiInst.side_effect = [
             int(-(sample * 2)) for sample in samples_dbm
@@ -1575,7 +1575,7 @@ class TestRaceConditionSimulations:
             radio._last_irq_status = IRQ_NONE
             await _wait_condition(
                 lambda: (
-                    not radio._is_receiving_packet and not radio._rx_done_event.is_set()
+                    not radio._processing_rx_packet and not radio._rx_done_event.is_set()
                 ),
                 timeout=1.0,
             )
@@ -2440,7 +2440,7 @@ class TestCoverageGapBranches:
 
     def test_noise_floor_sampling_handles_rssi_read_exception(self, radio, mock_lora):
         radio._last_packet_activity = 0.0
-        radio._is_receiving_packet = False
+        radio._processing_rx_packet = False
         mock_lora.getRssiInst.side_effect = RuntimeError("rssi error")
         radio._sample_noise_floor()  # must not raise
 
@@ -3107,7 +3107,7 @@ class TestCoverageSecondPass:
         radio._num_floor_samples = 0
         radio._floor_sample_sum = 0.0
         radio._last_packet_activity = 0.0
-        radio._is_receiving_packet = False
+        radio._processing_rx_packet = False
         mock_lora.getRssiInst.return_value = 100  # -50 dBm, valid range
 
         with patch(

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -1091,9 +1091,10 @@ class TestNoiseFloorSampling:
         radio.lora.getRssiInst.assert_not_called()
 
     def test_no_sample_during_active_rx_irq_flags(self, radio, mock_lora):
-        mock_lora.getIrqStatus.return_value = IRQ_PREAMBLE_DETECTED | IRQ_HEADER_VALID
-        with patch("openhop_core.hardware.sx1262_wrapper.time.time", return_value=40.0):
-            radio._sample_noise_floor()
+        with patch("openhop_core.hardware.sx1262_wrapper.time.monotonic", return_value=40.0):
+            radio._rx_activity_at = 40.0
+            with patch("openhop_core.hardware.sx1262_wrapper.time.time", return_value=40.0):
+                radio._sample_noise_floor()
         mock_lora.getRssiInst.assert_not_called()
 
     def test_no_sample_within_500ms_of_last_packet(self, radio):


### PR DESCRIPTION
**Noise-floor gate**: `_sample_noise_floor` read the hardware IRQ register directly, racing `_handle_interrupt`'s own clear of the same register. Now uses the new software latch `is_receiving_packet()` instead.

**TX-commit drain**: `_tx_lock` suppresses the background task's wake-up while it's held, so a packet that completes during that window just sits latched instead of being delivered. `_prepare_radio_for_tx` drains once at entry and `perform_cad` drains at the start of every scan, so most packets are caught mid-LBT-retry via the next CAD call. Two gaps remained: a packet completing on the loop's last check, when the budget runs out on that same check and no further CAD call happens; and back-to-back packets during a busy channel, since the `latch_defers` branch skips `perform_cad`'s drain entirely, so an earlier packet's buffer could be overwritten by a later one before ever being read out. The loop now drains at the top of every iteration, and once more right before committing to TX.

Also renamed `_is_receiving_packet` to `_processing_rx_packet`. It doesn't mean "a packet is arriving," it means "the background task is handling one it already caught," which was colliding in meaning with the `is_receiving_packet()` method.

### State timeline for one packet

| Event | `is_receiving_packet()` | `_pending_rx_irq_status` | `_processing_rx_packet` |
|:--|:--|:--|:--|
| Preamble detected | **True** | 0 | False |
| Header valid | True | 0 | False |
| Terminal IRQ (RX_DONE/CRC_ERR/HEADER_ERR) | **False** | **set** | False |
| Background task wakes, claims the bit | False | back to 0 | **True** |
| Buffer read, callback dispatched | False | 0 | True |
| Done | False | 0 | False |
