### PR TITLE
Corrupt-header packets, stale RSSI on drain, noise-floor gating

### DIFF
--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -508,6 +508,10 @@ class SX1262Radio(LoRaRadio):
                     self.crc_error_count += 1
                 elif pending_irq & self.lora.IRQ_RX_DONE:
                     payloadLengthRx, rxStartBufferPointer = self.lora.getRxBufferStatus()
+                    packet_rssi_dbm, snr_db, signal_rssi_dbm = self.lora.getSignalMetrics()
+                    self.last_rssi = int(packet_rssi_dbm)
+                    self.last_snr = snr_db
+                    self.last_signal_rssi = int(signal_rssi_dbm)
                     if payloadLengthRx > 0:
                         buffer = self.lora.readBuffer(rxStartBufferPointer, payloadLengthRx)
                         callback_packet_data = bytes(buffer)

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1596,16 +1596,8 @@ class SX1262Radio(LoRaRadio):
         if self._pending_rx_irq_status:
             return
 
-        # Skip during in-flight RX activity indicated by hardware IRQ flags.
-        rx_activity_mask = (
-            self.lora.IRQ_PREAMBLE_DETECTED
-            | self.lora.IRQ_HEADER_VALID
-            | self.lora.IRQ_RX_DONE
-            | self.lora.IRQ_CRC_ERR
-            | self.lora.IRQ_HEADER_ERR
-        )
-        irq_status = self.lora.getIrqStatus()
-        if irq_status & rx_activity_mask:
+        # Skip during in-flight RX activity.
+        if self.is_receiving_packet():
             return
 
         # Give 500ms quiet time after any packet activity

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -250,7 +250,7 @@ class SX1262Radio(LoRaRadio):
         self._floor_sample_sum = 0.0
         self._noise_floor_samples: list[float] = []
         self._last_packet_activity = 0.0
-        self._is_receiving_packet = False
+        self._processing_rx_packet = False
         self._last_sample_check = 0.0
         self.NUM_NOISE_FLOOR_SAMPLES = 20
         self.NOISE_FLOOR_UPDATE_INTERVAL = 5.0
@@ -573,7 +573,7 @@ class SX1262Radio(LoRaRadio):
                         _trace("[RX] RX_DONE event triggered!")
 
                         # Mark that we're processing a packet (prevents noise floor sampling)
-                        self._is_receiving_packet = True
+                        self._processing_rx_packet = True
                         self._last_packet_activity = time.time()
 
                         callback_packet_data = None
@@ -725,7 +725,7 @@ class SX1262Radio(LoRaRadio):
                             logger.error(f"[IRQ RX] Error processing received packet: {e}")
                         finally:
                             # Clear packet processing flag
-                            self._is_receiving_packet = False
+                            self._processing_rx_packet = False
 
                     except asyncio.TimeoutError:
                         # No RX event within timeout - normal operation
@@ -1590,14 +1590,12 @@ class SX1262Radio(LoRaRadio):
         if self._tx_lock.locked():
             return
 
-        # Don't sample if packet processing is active or RX terminal IRQs are pending.
-        if self._is_receiving_packet:
+        # Don't sample if we're receiving or processing a packet.
+        if self.is_receiving_packet():  # still arriving
             return
-        if self._pending_rx_irq_status:
+        if self._pending_rx_irq_status:  # arrived, waiting to be handled
             return
-
-        # Skip during in-flight RX activity.
-        if self.is_receiving_packet():
+        if self._processing_rx_packet:  # being handled now
             return
 
         # Give 500ms quiet time after any packet activity

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -391,7 +391,10 @@ class SX1262Radio(LoRaRadio):
                 self.lora.IRQ_RX_DONE | self.lora.IRQ_CRC_ERR | self.lora.IRQ_HEADER_ERR
             )
             if irqStat & rx_packet_irq_mask:
-                self._pending_rx_irq_status |= irqStat & rx_packet_irq_mask
+                if self._header_failed(irqStat):
+                    logger.debug(f"[RX] Discarded corrupt-header packet (0x{irqStat:04X})")
+                else:
+                    self._pending_rx_irq_status |= irqStat & rx_packet_irq_mask
 
             if irqStat != 0:
                 self.lora.clearIrqStatus(0xFFFF)
@@ -492,6 +495,10 @@ class SX1262Radio(LoRaRadio):
             if not self._tx_lock.locked():
                 self._rx_done_event.set()
 
+    def _header_failed(self, irq: int) -> bool:
+        """Header CRC failed with no valid header in the same read."""
+        return bool(irq & self.lora.IRQ_HEADER_ERR) and not (irq & self.lora.IRQ_HEADER_VALID)
+
     async def _drain_pending_rx_irq_before_buffer_reuse(self) -> None:
         """Drain latched packet-bearing RX IRQ state before CAD/TX buffer reuse."""
         if not self._pending_rx_irq_status:
@@ -521,8 +528,6 @@ class SX1262Radio(LoRaRadio):
                             f"({len(callback_packet_data)} bytes)"
                         )
 
-                if pending_irq & self.lora.IRQ_HEADER_ERR:
-                    logger.debug("[RX] Drained pending HEADER_ERR before TX/CAD")
             finally:
                 # Clear only after the latched IRQ state has been consumed.
                 self._pending_rx_irq_status = 0
@@ -646,6 +651,10 @@ class SX1262Radio(LoRaRadio):
                                             self.crc_error_count,
                                             diag_err,
                                         )
+                                elif self._header_failed(irqStat):
+                                    logger.debug(
+                                        f"[RX] Skipped corrupt-header packet " f"(0x{irqStat:04X})"
+                                    )
                                 elif irqStat & self.lora.IRQ_RX_DONE:
                                     (
                                         payloadLengthRx,

--- a/tests/test_sx1262_lbt.py
+++ b/tests/test_sx1262_lbt.py
@@ -215,6 +215,22 @@ async def test_lbt_standby_only_after_channel_clear(radio):
     assert radio.perform_cad.await_count == 1
 
 
+async def test_drain_updates_signal_metrics(radio):
+    """A packet delivered via drain must report its own RSSI/SNR, not
+    whatever was cached from the last packet the normal path handled."""
+    radio.set_rx_callback(lambda _: None)
+    radio.lora.getRxBufferStatus.return_value = (4, 0x80)
+    radio.lora.readBuffer.return_value = list(b"test")
+    radio.lora.getSignalMetrics.return_value = (-77.0, 6.5, -79.0)
+    radio._pending_rx_irq_status = IRQ_RX_DONE
+
+    await radio._drain_pending_rx_irq_before_buffer_reuse()
+
+    assert radio.last_rssi == -77
+    assert radio.last_snr == 6.5
+    assert radio.last_signal_rssi == -79
+
+
 # ─── LBT: time budget, not attempt count ─────────────────────────────
 
 

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -1326,6 +1326,26 @@ class TestEventOrdering:
         )
         assert read_idx < write_idx
 
+    async def test_corrupt_header_irq_is_not_latched(self, radio, mock_lora):
+        """0x0022 (RX_DONE | HEADER_ERR) with no header validated for this
+        reception: the length driving readBuffer is untrustworthy."""
+        radio._pending_rx_irq_status = 0
+
+        _inject_irq(radio, IRQ_RX_DONE | IRQ_HEADER_ERR)
+
+        assert radio._pending_rx_irq_status == 0
+
+    async def test_header_err_does_not_discard_an_already_latched_packet(
+        self, radio, mock_lora
+    ):
+        """Observed on-air: HEADER_ERR arriving while a good packet is still
+        unread. Latching it would OR to 0x0022 and lose a sound packet."""
+        radio._pending_rx_irq_status = IRQ_RX_DONE  # good packet, not yet read
+
+        _inject_irq(radio, IRQ_HEADER_ERR)
+
+        assert radio._pending_rx_irq_status == IRQ_RX_DONE
+
     async def test_rx_done_while_tx_lock_held_is_latched_and_drained_before_tx_reuse(
         self, radio, mock_lora
     ):

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -957,9 +957,9 @@ class TestRxBackgroundTask:
         assert radio.last_rssi == -85
         assert radio.last_snr == pytest.approx(7.5)
 
-    async def test_is_receiving_packet_flag_cleared_after_processing(self, radio):
+    async def test_processing_rx_packet_flag_cleared_after_processing(self, radio):
         await self._run_task_with(radio, irq_flags=IRQ_RX_DONE, callback=lambda _: None)
-        assert not radio._is_receiving_packet
+        assert not radio._processing_rx_packet
 
     async def test_crc_error_logs_diagnostic_info(self, radio, mock_lora, caplog):
         import logging
@@ -1079,7 +1079,7 @@ class TestNoiseFloorSampling:
         radio.lora.getRssiInst.assert_not_called()
 
     def test_no_sample_during_packet_reception(self, radio):
-        radio._is_receiving_packet = True
+        radio._processing_rx_packet = True
         with patch("openhop_core.hardware.sx1262_wrapper.time.time", return_value=20.0):
             radio._sample_noise_floor()
         radio.lora.getRssiInst.assert_not_called()
@@ -1114,7 +1114,7 @@ class TestNoiseFloorSampling:
     def test_sample_accepted_during_quiet_period(self, radio, mock_lora):
         mock_lora.getRssiInst.return_value = 160  # -80 dBm
         radio._last_packet_activity = 0.0
-        radio._is_receiving_packet = False
+        radio._processing_rx_packet = False
         with patch(
             "openhop_core.hardware.sx1262_wrapper.time.time", return_value=200.0
         ):
@@ -1124,7 +1124,7 @@ class TestNoiseFloorSampling:
 
     def test_rolling_window_averages_latest_20_samples(self, radio, mock_lora):
         radio._last_packet_activity = 0.0
-        radio._is_receiving_packet = False
+        radio._processing_rx_packet = False
         samples_dbm = [(-120.0 + i) for i in range(21)]
         mock_lora.getRssiInst.side_effect = [
             int(-(sample * 2)) for sample in samples_dbm
@@ -1575,7 +1575,7 @@ class TestRaceConditionSimulations:
             radio._last_irq_status = IRQ_NONE
             await _wait_condition(
                 lambda: (
-                    not radio._is_receiving_packet and not radio._rx_done_event.is_set()
+                    not radio._processing_rx_packet and not radio._rx_done_event.is_set()
                 ),
                 timeout=1.0,
             )
@@ -2440,7 +2440,7 @@ class TestCoverageGapBranches:
 
     def test_noise_floor_sampling_handles_rssi_read_exception(self, radio, mock_lora):
         radio._last_packet_activity = 0.0
-        radio._is_receiving_packet = False
+        radio._processing_rx_packet = False
         mock_lora.getRssiInst.side_effect = RuntimeError("rssi error")
         radio._sample_noise_floor()  # must not raise
 
@@ -3107,7 +3107,7 @@ class TestCoverageSecondPass:
         radio._num_floor_samples = 0
         radio._floor_sample_sum = 0.0
         radio._last_packet_activity = 0.0
-        radio._is_receiving_packet = False
+        radio._processing_rx_packet = False
         mock_lora.getRssiInst.return_value = 100  # -50 dBm, valid range
 
         with patch(

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -1091,9 +1091,10 @@ class TestNoiseFloorSampling:
         radio.lora.getRssiInst.assert_not_called()
 
     def test_no_sample_during_active_rx_irq_flags(self, radio, mock_lora):
-        mock_lora.getIrqStatus.return_value = IRQ_PREAMBLE_DETECTED | IRQ_HEADER_VALID
-        with patch("openhop_core.hardware.sx1262_wrapper.time.time", return_value=40.0):
-            radio._sample_noise_floor()
+        with patch("openhop_core.hardware.sx1262_wrapper.time.monotonic", return_value=40.0):
+            radio._rx_activity_at = 40.0
+            with patch("openhop_core.hardware.sx1262_wrapper.time.time", return_value=40.0):
+                radio._sample_noise_floor()
         mock_lora.getRssiInst.assert_not_called()
 
     def test_no_sample_within_500ms_of_last_packet(self, radio):


### PR DESCRIPTION
### 4 small RX fixes

**Discard packets whose LoRa header failed CRC**
Header CRC fails -> `PayloadLength` is garbage. We read that many bytes out and delivered them anyway.

**Report the drained packet's own RSSI/SNR**
That path never called `getSignalMetrics()`, so those packets got the previous packet's values.

**Gate noise-floor sampling on the reception latch**
It checked IRQ flags the handler had already cleared, so it sampled mid-reception.

Result on noise floor readings:
<img width="480" src="https://github.com/user-attachments/assets/09159537-8502-439d-a427-9c4344ff3507" />


**Rename `_is_receiving_packet` -> `_processing_rx_packet`**
Too close to `is_receiving_packet()`.