### PR TITLE
Gate the RX wake on TX buffer reuse to stop dropping RX packets

### DIFF
--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -168,6 +168,8 @@ class SX1262Radio(LoRaRadio):
         self._initialized = False
         self._rx_lock = asyncio.Lock()
         self._tx_lock = asyncio.Lock()
+        # Set from writeBuffer until TX completes.
+        self._tx_buffer_busy = False
 
         # GPIO management: prefer an explicitly provided manager (multi-CH341),
         # else a process-default external adapter manager, else a private
@@ -475,7 +477,7 @@ class SX1262Radio(LoRaRadio):
                 # Only wake the background task for TERMINAL interrupts
                 # Intermediate interrupts (preamble, sync, header valid) are just progress updates
                 if irqStat & terminal_interrupts:
-                    if not self._tx_lock.locked():
+                    if not self._tx_buffer_busy:
                         self._rx_done_event.set()
                         _trace(f"[RX] Terminal interrupt 0x{irqStat:04X} - waking background task")
                     else:
@@ -489,7 +491,7 @@ class SX1262Radio(LoRaRadio):
         except Exception as e:
             logger.error(f"IRQ handler error: {e}")
             self._tx_done_event.set()
-            if not self._tx_lock.locked():
+            if not self._tx_buffer_busy:
                 self._rx_done_event.set()
 
     async def _drain_pending_rx_irq_before_buffer_reuse(self) -> None:
@@ -1513,6 +1515,7 @@ class SX1262Radio(LoRaRadio):
                 if not tx_ready:
                     raise RuntimeError("Radio not ready for TX")
 
+                self._tx_buffer_busy = True
                 self._prepare_packet_transmission(data_list, length)
 
                 # Setup TX interrupts AFTER CAD checks (CAD changes interrupt config)
@@ -1527,6 +1530,7 @@ class SX1262Radio(LoRaRadio):
                 if not tx_ok:
                     raise RuntimeError("TX completion timeout")
 
+                self._tx_buffer_busy = False
                 self._finalize_transmission()
 
                 # Trigger TX LED

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1148,13 +1148,6 @@ class SX1262Radio(LoRaRadio):
     # ERROR. TRACE carries the chip-level minutiae.
     async def _prepare_radio_for_tx(self) -> tuple[bool, list[int]]:
         """Prepare radio hardware for transmission. Returns (success, lbt_backoff_delays_ms)."""
-        self._tx_done_event.clear()
-        self._rx_done_event.clear()
-
-        # Drain any packet-bearing RX IRQ that fired while TX was active and was
-        # latched in software before we begin CAD/TX buffer reuse.
-        await self._drain_pending_rx_irq_before_buffer_reuse()
-
         # Listen Before Talk, bounded in TIME rather than attempts: short
         # jittered retries run for the whole budget, keeping two nodes' checks
         # decorrelated and bounding the post-clear latency to one retry
@@ -1255,6 +1248,13 @@ class SX1262Radio(LoRaRadio):
             if self.lora.busyCheck():
                 logger.error("[TX] Radio stayed busy - aborting")
                 return False, lbt_backoff_delays
+
+        self._tx_done_event.clear()
+        self._rx_done_event.clear()
+
+        # Drain here rather than before the LBT loop: a packet latched during
+        # the backoffs would otherwise be clobbered by the buffer reuse below.
+        await self._drain_pending_rx_irq_before_buffer_reuse()
 
         return True, lbt_backoff_delays
 

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1201,7 +1201,7 @@ class SX1262Radio(LoRaRadio):
                 # the radio is still receiving, and re-arming would clear the
                 # IRQ flags and drop to standby — aborting the very reception
                 # that set the latch, with no terminal IRQ left to clear it.
-                await self._restore_rx_for_cad_backoff()
+                await self._restore_rx_mode()
             logger.debug(f"[LBT] Channel busy - retrying in {delay_ms:.0f}ms")
             await asyncio.sleep(delay_ms / 1000.0)
 
@@ -1245,31 +1245,6 @@ class SX1262Radio(LoRaRadio):
                 return False, lbt_backoff_delays
 
         return True, lbt_backoff_delays
-
-    async def _restore_rx_for_cad_backoff(self) -> None:
-        """Restore RX_CONTINUOUS between busy CAD retries."""
-        # Deterministic transition sequence:
-        # clear IRQs -> standby -> disable IRQ routes -> set RX IRQ routes -> RX_CONTINUOUS.
-        # This keeps receive downtime minimal while preserving a fresh CAD immediately
-        # before each transmit attempt.
-        self.lora.clearIrqStatus(0xFFFF)
-        self.lora.setStandby(self.lora.STANDBY_RC)
-        await asyncio.sleep(self.RADIO_TIMING_DELAY)
-        self.lora.setDioIrqParams(
-            self.lora.IRQ_NONE,
-            self.lora.IRQ_NONE,
-            self.lora.IRQ_NONE,
-            self.lora.IRQ_NONE,
-        )
-        await asyncio.sleep(0.001)
-        self.lora.clearIrqStatus(0xFFFF)
-        rx_mask = self._get_rx_irq_mask()
-        self.lora.setDioIrqParams(rx_mask, rx_mask, self.lora.IRQ_NONE, self.lora.IRQ_NONE)
-        await asyncio.sleep(0.001)
-        self._control_tx_rx_pins(tx_mode=False)
-        self.lora.request(self.lora.RX_CONTINUOUS)
-        await asyncio.sleep(self.RADIO_TIMING_DELAY)
-        self.lora.clearIrqStatus(0xFFFF)
 
     def _control_tx_rx_pins(self, tx_mode: bool) -> None:
         """Control TXEN/RXEN pins for the E22 module (simple and deterministic)."""
@@ -1444,50 +1419,31 @@ class SX1262Radio(LoRaRadio):
         self._control_tx_rx_pins(tx_mode=False)
 
     async def _restore_rx_mode(self) -> None:
-        """Restore radio to RX continuous mode after transmission"""
-        _trace("[TX->RX] Starting RX mode restoration after transmission")
+        """Return the radio to RX_CONTINUOUS.
+
+        Command order per SX1261/2 datasheet 14.3: standby, SetDioIrqParams,
+        SetRx. The RF switch is set first so the receive path is connected
+        before the chip starts listening.
+        """
         try:
-            if self.lora:
-                # Critical sequence to prevent interrupt race conditions
+            if not self.lora:
+                return
 
-                # Step 1: Clear all interrupts first
-                self.lora.clearIrqStatus(0xFFFF)
+            self._control_tx_rx_pins(tx_mode=False)
 
-                # Step 2: Put radio in standby
-                self.lora.setStandby(self.lora.STANDBY_RC)
-                await asyncio.sleep(self.RADIO_TIMING_DELAY)
+            self.lora.setStandby(self.lora.STANDBY_RC)
+            await asyncio.sleep(self.RADIO_TIMING_DELAY)
 
-                # Step 3: Disable all interrupts temporarily during reconfiguration
-                self.lora.setDioIrqParams(
-                    self.lora.IRQ_NONE,
-                    self.lora.IRQ_NONE,
-                    self.lora.IRQ_NONE,
-                    self.lora.IRQ_NONE,
-                )
-                await asyncio.sleep(0.001)
+            self.lora.clearIrqStatus(0xFFFF)
+            rx_mask = self._get_rx_irq_mask()
+            self.lora.setDioIrqParams(rx_mask, rx_mask, self.lora.IRQ_NONE, self.lora.IRQ_NONE)
 
-                # Step 4: Clear any interrupts that may have fired
-                self.lora.clearIrqStatus(0xFFFF)
+            self.lora.request(self.lora.RX_CONTINUOUS)
+            await asyncio.sleep(self.RADIO_TIMING_DELAY)
 
-                # Step 5: Restore RX interrupt configuration
-                rx_mask = self._get_rx_irq_mask()
-                self.lora.setDioIrqParams(rx_mask, rx_mask, self.lora.IRQ_NONE, self.lora.IRQ_NONE)
-                await asyncio.sleep(0.001)
-
-                # Step 6: Start RX mode
-                self.lora.request(self.lora.RX_CONTINUOUS)
-                await asyncio.sleep(self.RADIO_TIMING_DELAY)
-
-                # Step 7: Final interrupt clear to start fresh
-                self.lora.clearIrqStatus(0xFFFF)
-
-                # Always restore external RF switch control pins to RX mode
-                self._control_tx_rx_pins(tx_mode=False)
-
-                _trace("[TX->RX] RX mode restoration completed")
-
+            _trace("[RX] RX_CONTINUOUS restored")
         except Exception as e:
-            logger.warning(f"[TX->RX] Failed to restore RX mode after TX: {e}")
+            logger.warning(f"[RX] Failed to restore RX mode: {e}")
 
     async def send(self, data: bytes) -> dict:
         """Send a packet asynchronously. Returns transmission metadata including LBT metrics."""

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -386,6 +386,9 @@ class SX1262Radio(LoRaRadio):
                 return
 
             irqStat = self.lora.getIrqStatus()
+            # Snapshot before this IRQ's own bits are latched below, or a single
+            # read carrying both a terminal and a marker flags itself.
+            unread = self._pending_rx_irq_status & self.lora.IRQ_RX_DONE
 
             # Preserve packet-bearing RX terminal IRQs in software before the
             # hardware IRQ status is cleared.
@@ -393,6 +396,10 @@ class SX1262Radio(LoRaRadio):
                 self.lora.IRQ_RX_DONE | self.lora.IRQ_CRC_ERR | self.lora.IRQ_HEADER_ERR
             )
             if irqStat & rx_packet_irq_mask:
+                if unread:
+                    logger.warning(
+                        f"[RX] Packet lost: unread RX_DONE overwritten by " f"IRQ 0x{irqStat:04X}"
+                    )
                 self._pending_rx_irq_status |= irqStat & rx_packet_irq_mask
 
             if irqStat != 0:
@@ -434,6 +441,11 @@ class SX1262Radio(LoRaRadio):
                     | self.lora.IRQ_HEADER_VALID
                 )
                 if irqStat & reception_markers:
+                    if unread:
+                        logger.warning(
+                            f"[RX] Unread packet at risk: reception started "
+                            f"(IRQ 0x{irqStat:04X})"
+                        )
                     now_mono = time.monotonic()
                     if irqStat & self.lora.IRQ_HEADER_VALID:
                         # Header valid restarts the clock onto the longer bound.

--- a/tests/test_sx1262_lbt.py
+++ b/tests/test_sx1262_lbt.py
@@ -156,6 +156,7 @@ async def test_lbt_defers_to_in_progress_reception_without_cad(radio):
     """While a reception is latched, the LBT loop must wait on the passive
     check alone: running CAD would drop to standby and abort the reception it
     is probing for. The CAD scan happens only once the latch clears."""
+    radio._max_preamble_seconds = lambda: 10.0  # keep expiry out of the picture
     _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
     radio.perform_cad = AsyncMock(return_value=False)
     radio._restore_rx_for_cad_backoff = AsyncMock()
@@ -183,6 +184,7 @@ async def test_lbt_does_not_touch_the_radio_while_a_reception_is_latched(radio):
     IRQ left to clear it, the latch would then block TX until it goes stale.
     Only a CAD scan leaves standby behind, so only a scan needs the re-arm.
     """
+    radio._max_preamble_seconds = lambda: 10.0  # keep expiry out of the picture
     _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
     radio.perform_cad = AsyncMock(return_value=False)
     radio._restore_rx_for_cad_backoff = AsyncMock()
@@ -300,6 +302,7 @@ async def test_lbt_summary_reports_cad_clear(radio, caplog):
 
 
 async def test_lbt_summary_counts_latch_defers_separately_from_cad(radio, caplog):
+    radio._max_preamble_seconds = lambda: 10.0  # keep expiry out of the picture
     _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
     radio.perform_cad = AsyncMock(return_value=False)
     radio._restore_rx_for_cad_backoff = AsyncMock()

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -388,31 +388,31 @@ class TestInterruptHandlerDispatch:
 class TestIrqSuppressionDuringTx:
     """Terminal RX interrupts must be ignored while _tx_lock is held."""
 
-    async def test_rx_done_suppressed_while_tx_locked(self, radio):
+    @pytest.mark.parametrize(
+        "irq", [IRQ_RX_DONE, IRQ_CRC_ERR, IRQ_TIMEOUT, IRQ_HEADER_ERR]
+    )
+    async def test_terminal_irq_delivered_while_only_tx_lock_held(self, radio, irq):
+        """Holding _tx_lock must not suppress the RX wake: the event has no
+        counter, so a skipped set() is deleted rather than deferred."""
         async with radio._tx_lock:
             radio._rx_done_event.clear()
-            _inject_irq(radio, IRQ_RX_DONE)
-            assert not radio._rx_done_event.is_set(), (
-                "RX_DONE must NOT wake background task during active TX"
+            _inject_irq(radio, irq)
+            assert radio._rx_done_event.is_set(), (
+                f"terminal IRQ 0x{irq:04X} must wake the RX task while only _tx_lock is held"
             )
 
-    async def test_crc_err_suppressed_while_tx_locked(self, radio):
-        async with radio._tx_lock:
+    @pytest.mark.parametrize(
+        "irq", [IRQ_RX_DONE, IRQ_CRC_ERR, IRQ_TIMEOUT, IRQ_HEADER_ERR]
+    )
+    async def test_terminal_irq_suppressed_while_tx_buffer_busy(self, radio, irq):
+        """The wake is gated only while the shared buffer is being reused."""
+        radio._tx_buffer_busy = True
+        try:
             radio._rx_done_event.clear()
-            _inject_irq(radio, IRQ_CRC_ERR)
+            _inject_irq(radio, irq)
             assert not radio._rx_done_event.is_set()
-
-    async def test_timeout_irq_suppressed_while_tx_locked(self, radio):
-        async with radio._tx_lock:
-            radio._rx_done_event.clear()
-            _inject_irq(radio, IRQ_TIMEOUT)
-            assert not radio._rx_done_event.is_set()
-
-    async def test_header_err_suppressed_while_tx_locked(self, radio):
-        async with radio._tx_lock:
-            radio._rx_done_event.clear()
-            _inject_irq(radio, IRQ_HEADER_ERR)
-            assert not radio._rx_done_event.is_set()
+        finally:
+            radio._tx_buffer_busy = False
 
     async def test_tx_done_event_fires_even_while_tx_locked(self, radio):
         """TX_DONE must still propagate so the sender coroutine can unblock."""
@@ -689,9 +689,19 @@ class TestTransmissionLifecycle:
         await radio._restore_rx_mode()
         mock_lora.request.assert_called_with(mock_lora.RX_CONTINUOUS)
 
-    async def test_restore_rx_mode_clears_irq_multiple_times(self, radio, mock_lora):
+    async def test_restore_rx_mode_follows_datasheet_order(self, radio, mock_lora):
+        """Datasheet 14.3: standby, SetDioIrqParams, SetRx - and the RF switch
+        connected before the chip starts listening."""
+        calls = []
+        mock_lora.setStandby.side_effect = lambda *a, **k: calls.append("standby")
+        mock_lora.setDioIrqParams.side_effect = lambda *a, **k: calls.append("irq_params")
+        mock_lora.request.side_effect = lambda *a, **k: calls.append("set_rx")
+        radio._control_tx_rx_pins = lambda tx_mode: calls.append("rf_switch")
+
         await radio._restore_rx_mode()
-        assert mock_lora.clearIrqStatus.call_count >= 2
+
+        assert calls.index("rf_switch") < calls.index("set_rx")
+        assert calls.index("standby") < calls.index("irq_params") < calls.index("set_rx")
 
     async def test_restore_rx_mode_exception_swallowed(self, radio, mock_lora):
         mock_lora.clearIrqStatus.side_effect = RuntimeError("SPI failure")
@@ -1333,15 +1343,15 @@ class TestEventOrdering:
 
         await radio._tx_lock.acquire()
         try:
-            # IRQ arrives while TX lock is held: hardware IRQ is cleared and
-            # background RX task is not woken, so software latch must preserve it.
+            # IRQ arrives while TX lock is held: the wake now fires regardless,
+            # and the software latch still preserves the packet for buffer reuse.
             mock_lora.getIrqStatus.return_value = mock_lora.IRQ_RX_DONE
             radio._handle_interrupt()
         finally:
             radio._tx_lock.release()
 
         assert radio._pending_rx_irq_status & mock_lora.IRQ_RX_DONE
-        assert not radio._rx_done_event.is_set()
+        assert radio._rx_done_event.is_set()
 
         mock_lora.getRxBufferStatus.return_value = (4, 0x80)
         mock_lora.readBuffer.return_value = list(b"test")


### PR DESCRIPTION
We hold `_tx_lock` across the whole LBT loop, up to 4s. The IRQ handler used it to decide whether to wake the RX task:

```python
if not self._tx_lock.locked():
    self._rx_done_event.set()
```

Skipping `set()` deletes the wake-up. The packet sits unread. Second packet arrives:

```python
self._pending_rx_irq_status |= irqStat & rx_packet_irq_mask
```

`RX_DONE` already set -> OR does nothing. Second packet overwrites the first, silently.

Predates #116, which roughly doubled the lock hold time (5 attempts exponential -> 4s budget) and took loss from 0.27% to 6.09%.

### Proposed fix

The interrupt handler gates on `_tx_buffer_busy` (set from `writeBuffer` until TX completes) instead of `_tx_lock`. The difference is that `_tx_lock` was held while the radio was actively receiving, whereas `_tx_buffer_busy` only covers the window where we're transmitting and no RX can arrive anyway.

`_tx_lock` keeps its original scope, held across the whole send. It no longer has anything to do with RX delivery.

This also means the buffer can be read during a CAD scan, which is safe: CAD only produces `CadDone`/`CadDetected` and never touches the data buffer (datasheet §13.1.8).

`_tx_buffer_busy` can never actually be true when the handler checks it: there's no await between setting it and masking RX IRQs, and after that we're transmitting. It's kept as a cheap guard.

### Evidence

Measured with temporary instrumentation (not in this PR) reading `GetStats()`, which returns `NbPktReceived`, incremented by the chip itself for every CRC-valid packet.

```
packets the radio counted  -  packets we delivered  =  lost in software
```

| build | duration | packets | lost |
|---|---|---|---|
| before #116 | 5.9h | 1092 | 3 (0.27%) |
| current `dev` | 1.1h | 312 | **19 (6.09%)** |
| this PR | 11.6h | 2946 | **0** |

___

Also merged `_restore_rx_for_cad_backoff` into `_restore_rx_mode` (same sequence duplicated), ordered per SX1262 datasheet §14.3. Fixes the RF switch being flipped to RX *after* `SetRx`, which left us deaf ~10ms after every TX.