### PR TITLE
fix(companion): handle app-tracked ACKs like firmware

### DIFF
--- a/src/openhop_core/companion/companion_radio.py
+++ b/src/openhop_core/companion/companion_radio.py
@@ -445,9 +445,13 @@ class CompanionRadio(CompanionBase):
         rssi = getattr(pkt, "rssi", getattr(pkt, "_rssi", 0))
         await self._fire_callbacks("rx_log_data", snr, rssi, data)
 
-    async def _on_ack_received(self, crc: int) -> None:
-        """Called by dispatcher when an ACK CRC is received; fire send_confirmed if pending."""
-        await self._try_confirm_send(crc)
+    async def _on_ack_received(self, crc: int) -> bool:
+        """Called by dispatcher when an ACK CRC is received; fire send_confirmed if pending.
+
+        Returns whether the CRC matched a pending app-side send, so the ACK
+        handler can mark the packet do-not-retransmit (firmware onAckRecv).
+        """
+        return await self._try_confirm_send(crc)
 
     async def _on_raw_custom_received(self, pkt: Packet) -> None:
         """Dispatcher RAW_CUSTOM handler: fire raw_data_received(payload, snr, rssi)."""

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -21,7 +21,7 @@ from ..protocol.packet_utils import PathUtils, calculate_lora_airtime_ms, flood_
 from ..protocol.region_map import RegionMap, capture_recv_region
 from ..protocol.transport_keys import scope_packet
 from ..protocol.utils import PAYLOAD_TYPES, ROUTE_TYPES
-from ..util.callbacks import invoke_maybe_awaitable
+from ..util.callbacks import AckReceivedCallback, invoke_maybe_awaitable
 
 # Import handler classes
 from .handlers import (
@@ -102,7 +102,7 @@ class Dispatcher:
         self.packet_sent_callback: Optional[Callable[[Packet], Awaitable[None] | None]] = None
 
         # Optional listener for ACK received (e.g. companion send_confirmed)
-        self._ack_received_listener: Optional[Callable[[int], Awaitable[None] | None]] = None
+        self._ack_received_listener: Optional[AckReceivedCallback] = None
 
         # Optional callback for PAYLOAD_TYPE_RAW_CUSTOM (companion raw_data_received)
         self.raw_data_received_callback: Optional[Callable[[Packet], Awaitable[None]]] = None
@@ -435,9 +435,14 @@ class Dispatcher:
 
     def set_ack_received_listener(
         self,
-        callback: Optional[Callable[[int], Awaitable[None] | None]],
+        callback: Optional[AckReceivedCallback],
     ) -> None:
-        """Set optional listener for ACK CRCs (e.g. companion send_confirmed)."""
+        """Set optional listener for received ACK CRCs (e.g. a companion's send_confirmed).
+
+        See :data:`AckReceivedCallback`: the listener returns whether the CRC matched one of
+        this node's own pending sends (truthy = consumed, drives do-not-retransmit; False/None =
+        not mine). A ``None``-returning listener keeps the older notify-only behaviour.
+        """
         self._ack_received_listener = callback
 
     def set_raw_packet_callback(self, callback: Callable[..., Awaitable[None] | None]) -> None:
@@ -1363,8 +1368,14 @@ class Dispatcher:
     # All ACK processing logic is delegated to the AckHandler.
     # ------------------------------------------------------------------
 
-    async def _register_ack_received(self, crc: int) -> None:
-        """Record that an ACK with the given CRC was received."""
+    async def _register_ack_received(self, crc: int) -> bool:
+        """Record that an ACK with the given CRC was received.
+
+        Returns whether an application listener reported consuming the CRC
+        (matched a send it tracks app-side), so the ACK handler can mark the
+        packet do-not-retransmit (firmware onAckRecv). A dispatcher-level
+        waiter is reported separately by the handler via ``_waiting_acks``.
+        """
         ts = asyncio.get_running_loop().time()
         self._recent_acks[crc] = ts
 
@@ -1374,7 +1385,8 @@ class Dispatcher:
             evt.set()
 
         if self._ack_received_listener:
-            await self._invoke_ack_listener(crc)
+            return bool(await self._invoke_ack_listener(crc))
+        return False
 
     async def run_forever(self) -> None:
         """Run the dispatcher maintenance loop until :meth:`stop` is awaited.
@@ -1457,12 +1469,16 @@ class Dispatcher:
     async def _invoke_callback(self, cb, pkt: Packet) -> None:
         await invoke_maybe_awaitable(cb, pkt)
 
-    async def _invoke_ack_listener(self, crc: int) -> None:
-        """Invoke ack-received listener (sync or async)."""
+    async def _invoke_ack_listener(self, crc: int) -> Optional[bool]:
+        """Invoke the ack-received listener (sync or async) and return its result.
+
+        Per :data:`AckReceivedCallback`, the listener reports whether the CRC matched one of this
+        node's own pending sends; the caller propagates that to the do-not-retransmit decision.
+        """
         cb = self._ack_received_listener
         if cb is None:
-            return
-        await invoke_maybe_awaitable(cb, crc)
+            return None
+        return bool(await invoke_maybe_awaitable(cb, crc))
 
     async def _invoke_enhanced_raw_callback(
         self, callback, pkt: Packet, data: bytes, analysis: dict

--- a/src/openhop_core/node/handlers/ack.py
+++ b/src/openhop_core/node/handlers/ack.py
@@ -83,9 +83,17 @@ class AckHandler(BaseHandler):
         # PATH returns are encrypted as dest_hash + src_hash + MAC + ciphertext.
         # Their outer length varies with the returned path, so do not restrict this
         # to the 20-byte (single AES-block) form.
+        #
+        # Deliberately NOT gated on dispatcher._waiting_acks: firmware
+        # Mesh::onRecvPacket processes every PATH addressed to this node
+        # unconditionally (Mesh.cpp PAYLOAD_TYPE_PATH case: decrypt, then
+        # onPeerPathRecv with extra_type/extra). A companion never populates
+        # _waiting_acks — it tracks expected ACK CRCs app-side and relies on the
+        # ack-received listener — so gating here made the delivery confirmation
+        # for a flood text message (whose ACK rides the PATH return) invisible
+        # to companion clients.
         if (
-            self.dispatcher._waiting_acks
-            and self.dispatcher.local_identity
+            self.dispatcher.local_identity
             and self.dispatcher.contact_book
             and len(payload) >= 2
             and payload[0] == self.dispatcher.local_identity.get_public_key()[0]
@@ -137,10 +145,12 @@ class AckHandler(BaseHandler):
                 self.log("Encrypted PATH ACK extra is shorter than its CRC")
                 return None
 
-            crc = int.from_bytes(decrypted[extra_start + 1 : extra_start + 5], "little")
-            if crc in self.dispatcher._waiting_acks:
-                return crc
-            return None
+            # Return the CRC of any authenticated embedded ACK. Matching it
+            # against a waiter is the notify path's job: dispatcher-level
+            # waiters resolve through _waiting_acks, and a companion matches it
+            # against its app-side expected-ACK table (firmware processAck
+            # ignores CRCs it does not know, so an unknown CRC is harmless).
+            return int.from_bytes(decrypted[extra_start + 1 : extra_start + 5], "little")
 
         return None
 

--- a/src/openhop_core/node/handlers/ack.py
+++ b/src/openhop_core/node/handlers/ack.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Awaitable, Callable, Optional
+from typing import Optional
 
 from ...protocol import Packet
 from ...protocol.constants import PAYLOAD_TYPE_ACK
 from ...protocol.packet_utils import PathUtils
-from ...util.callbacks import invoke_maybe_awaitable
+from ...util.callbacks import AckReceivedCallback, invoke_maybe_awaitable
 from .base import BaseHandler
 from .crypto_helpers import iter_decrypt_by_src_hash
 
@@ -25,12 +25,14 @@ class AckHandler(BaseHandler):
     def __init__(self, log_fn, dispatcher=None):
         self.log = log_fn
         self.dispatcher = dispatcher
-        self._ack_received_callback: Optional[Callable[[int], Awaitable[None] | None]] = None
+        self._ack_received_callback: Optional[AckReceivedCallback] = None
 
-    def set_ack_received_callback(
-        self, callback: Optional[Callable[[int], Awaitable[None] | None]]
-    ):
-        """Set callback to notify dispatcher when ACK is received."""
+    def set_ack_received_callback(self, callback: Optional[AckReceivedCallback]):
+        """Set the ACK-received callback (the dispatcher's _register_ack_received).
+
+        See :data:`AckReceivedCallback`: it returns whether the CRC matched one of this node's
+        own pending sends (truthy = consumed -> do-not-retransmit; False/None = not mine).
+        """
         self._ack_received_callback = callback
 
     def set_dispatcher(self, dispatcher):
@@ -44,10 +46,18 @@ class AckHandler(BaseHandler):
             # Firmware BaseChatMesh::onAckRecv marks the packet do-not-retransmit
             # when the ACK matches a message this node sent (processAck != NULL),
             # so a client repeater does not re-flood an ACK addressed to itself.
-            # _waiting_acks holds the CRCs we are awaiting — the Core equivalent.
+            # Two places can be awaiting it: dispatcher-level waiters
+            # (_waiting_acks) and an application listener (a companion tracks
+            # expected ACK CRCs app-side). Mark for a dispatcher waiter BEFORE
+            # notifying — the notify callback resolves and pops that waiter, and
+            # marking first also keeps the packet marked when a listener raises
+            # (the pre-existing guarantee). A listener-consumed ACK can only be
+            # marked after the listener reports it.
             if self.dispatcher is not None and ack_crc in self.dispatcher._waiting_acks:
                 packet.mark_do_not_retransmit()
-            await self._notify_ack_received(ack_crc)
+            consumed = await self._notify_ack_received(ack_crc)
+            if consumed:
+                packet.mark_do_not_retransmit()
 
     async def process_discrete_ack(self, packet: Packet) -> Optional[int]:
         """Process a discrete ACK packet and return the CRC if valid."""
@@ -154,7 +164,9 @@ class AckHandler(BaseHandler):
 
         return None
 
-    async def _notify_ack_received(self, crc: int):
-        """Notify the dispatcher that an ACK was received."""
+    async def _notify_ack_received(self, crc: int) -> Optional[bool]:
+        """Notify the registered ACK callback; return its result (truthy when the ACK was
+        consumed/matched app-side, so the caller marks the packet do-not-retransmit)."""
         if self._ack_received_callback:
-            await invoke_maybe_awaitable(self._ack_received_callback, crc)
+            return await invoke_maybe_awaitable(self._ack_received_callback, crc)
+        return None

--- a/src/openhop_core/node/handlers/path.py
+++ b/src/openhop_core/node/handlers/path.py
@@ -68,7 +68,15 @@ class PathHandler:
             if self._ack_handler:
                 ack_crc = await self._ack_handler.process_path_ack_variants(pkt)
                 if ack_crc is not None:
-                    # ACK was found, notify dispatcher
+                    # A successfully MAC-verified/decrypted PATH proves the packet
+                    # belongs to this identity, so it is authenticated regardless
+                    # of whether anything is awaiting the embedded CRC — firmware
+                    # Mesh::onRecvPacket sets `found` (and marks do-not-retransmit)
+                    # on MACThenDecrypt success alone; whether the CRC confirms a
+                    # particular send is processAck's separate, app-level decision.
+                    # HandlerResult.authenticated carries the consume/no-forward
+                    # decision to both the dispatcher and the companion bridge.
+                    authenticated = True
                     await self._ack_handler._notify_ack_received(ack_crc)
 
             # Optional PATH packet analysis if analyzer is available

--- a/src/openhop_core/util/callbacks.py
+++ b/src/openhop_core/util/callbacks.py
@@ -3,17 +3,29 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable, Optional
+
+# Contract for an ACK-received listener/callback: given a received ACK CRC, it reports whether
+# that CRC matched (was consumed by) one of THIS node's own pending sends.
+#   truthy  -> the ACK is one of mine; the ack handler marks the packet do-not-retransmit so a
+#              client repeater does not re-flood an ACK addressed to itself (firmware
+#              BaseChatMesh::onAckRecv / Mesh::onRecvPacket).
+#   False / None -> not one of mine (take no do-not-retransmit action).
+# The callback may be synchronous or asynchronous; a ``None``-returning callback stays
+# backward-compatible with the older notify-only contract.
+AckReceivedCallback = Callable[[int], "Awaitable[Optional[bool]] | Optional[bool]"]
 
 
-async def invoke_maybe_awaitable(callback: Callable[..., Any], *args: Any) -> None:
+async def invoke_maybe_awaitable(callback: Callable[..., Any], *args: Any) -> Any:
     """Call ``callback(*args)`` and await the result when it is awaitable.
 
     True ``async def`` callbacks, sync wrappers that return a coroutine or
     other awaitable, and callable objects with ``async def __call__`` are
     all awaited inline. Plain sync callbacks that return ``None`` (or any
-    non-awaitable) complete without scheduling.
+    non-awaitable) complete without scheduling. The callback's result is
+    returned so callers can act on it.
     """
     result = callback(*args)
     if inspect.isawaitable(result):
-        await result
+        return await result
+    return result

--- a/tests/test_path_ack_handler.py
+++ b/tests/test_path_ack_handler.py
@@ -344,3 +344,90 @@ async def test_path_handler_updates_matched_contact_sends_reciprocal_and_resolve
         shared_secret[:16], shared_secret, bytes(reciprocal.payload[2:])
     )
     assert reciprocal_inner[:3] == bytes([PathUtils.encode_path_len(1, 1), 0xC3, 0xFF])
+
+
+
+
+@pytest.mark.asyncio
+async def test_path_embedded_ack_notifies_listener_without_dispatcher_waiters():
+    """Companion flow: the app (not the dispatcher) tracks expected ACK CRCs.
+
+    Firmware Mesh::onRecvPacket decrypts every PATH addressed to this node and
+    hands its extra (the embedded ACK for a flood text message) to processAck —
+    with no dispatcher-level waiting-ack precondition. The PATH-embedded ACK
+    must therefore reach the ack-received listener even when _waiting_acks is
+    empty, or a companion client never sees delivery confirmation for a flood DM.
+    """
+    contacts = ContactStore()
+    contacts.load_from([Contact(public_key=SENDER_IDENTITY.get_public_key(), name="peer")])
+    ack_crc = 0x12345678
+    dispatcher = SimpleNamespace(
+        local_identity=LOCAL_IDENTITY,
+        contact_book=contacts,
+        _waiting_acks={},  # companion: nothing waits at dispatcher level
+    )
+    handler = AckHandler(lambda _message: None, dispatcher)
+
+    notified = []
+
+    async def listener(crc):
+        notified.append(crc)
+
+    handler.set_ack_received_callback(listener)
+
+    packet = _path_return(
+        LOCAL_IDENTITY,
+        SENDER_IDENTITY,
+        path=[],
+        extra_type=PAYLOAD_TYPE_ACK,
+        extra=ack_crc.to_bytes(4, "little"),
+    )
+    found = await handler.process_path_ack_variants(packet)
+    assert found == ack_crc
+    await handler._notify_ack_received(found)
+    assert notified == [ack_crc]
+
+
+
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("listener_consumes", [True, False])
+async def test_decrypted_path_ack_is_authenticated_regardless_of_consumption(listener_consumes):
+    """Firmware parity for PATH packets (Mesh::onRecvPacket): a successful
+    MAC-then-decrypt alone proves the PATH belongs to this identity, so the
+    handler returns authenticated — whether or not the embedded CRC matched a
+    pending send (that match is processAck's separate, app-level decision).
+    HandlerResult.authenticated then drives do-not-retransmit in the dispatcher
+    and the forwarding decision in the companion bridge.
+    """
+    contacts = ContactStore()
+    contacts.add(Contact(public_key=SENDER_IDENTITY.get_public_key(), name="peer"))
+    ack_crc = 0x12345678
+    dispatcher = Dispatcher(_CallbackRadio())
+    dispatcher.local_identity = LOCAL_IDENTITY
+    dispatcher.set_contact_book(contacts)
+    notified: list[int] = []
+
+    def listener(crc):
+        notified.append(crc)
+        return listener_consumes
+
+    dispatcher.set_ack_received_listener(listener)
+
+    ack_handler = AckHandler(lambda _m: None, dispatcher)
+    ack_handler.set_ack_received_callback(dispatcher._register_ack_received)
+
+    packet = _path_return(
+        LOCAL_IDENTITY,
+        SENDER_IDENTITY,
+        path=[],
+        extra_type=PAYLOAD_TYPE_ACK,
+        extra=ack_crc.to_bytes(4, "little"),
+    )
+    result = await PathHandler(lambda _m: None, ack_handler=ack_handler)(packet)
+    assert result.authenticated is True, (
+        "a MAC-verified PATH is authenticated independent of CRC consumption"
+    )
+    assert notified == [ack_crc], "the embedded CRC must still reach the listener"
+

--- a/tests/test_path_ack_handler.py
+++ b/tests/test_path_ack_handler.py
@@ -346,8 +346,6 @@ async def test_path_handler_updates_matched_contact_sends_reciprocal_and_resolve
     assert reciprocal_inner[:3] == bytes([PathUtils.encode_path_len(1, 1), 0xC3, 0xFF])
 
 
-
-
 @pytest.mark.asyncio
 async def test_path_embedded_ack_notifies_listener_without_dispatcher_waiters():
     """Companion flow: the app (not the dispatcher) tracks expected ACK CRCs.
@@ -388,7 +386,87 @@ async def test_path_embedded_ack_notifies_listener_without_dispatcher_waiters():
     assert notified == [ack_crc]
 
 
+class _CompanionMockRadio:
+    """Minimal radio for a real CompanionRadio: set_rx_callback + async send."""
 
+    def __init__(self):
+        self.rx_callback = None
+        self.sent: list[bytes] = []
+
+    def set_rx_callback(self, callback):
+        self.rx_callback = callback
+
+    async def send(self, data: bytes) -> bool:
+        self.sent.append(data)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_companion_tracked_ack_end_to_end_confirms_and_suppresses():
+    """The real CompanionRadio wiring, end to end: an ACK whose CRC sits in the
+    companion's app-side pending table must clear that entry, fire
+    send_confirmed, and be marked do-not-retransmit — through the dispatcher's
+    registered ACK handler, exactly as a received radio packet would travel.
+    This is the central behavioural change (firmware onAckRecv processAck
+    match): the listener's consumed result must survive the full
+    CompanionRadio._on_ack_received -> dispatcher -> AckHandler chain.
+    """
+    from openhop_core.companion import CompanionRadio
+
+    ack_crc = 0x0BADF00D
+    comp = CompanionRadio(_CompanionMockRadio(), LocalIdentity())
+    comp._track_pending_ack(ack_crc)
+
+    confirmed: list[int] = []
+    comp.on_send_confirmed(lambda crc, trip_ms: confirmed.append(crc))
+
+    packet = Packet()
+    packet.header = 1 << 2  # PAYLOAD_TYPE_ACK, route flood
+    packet.path_len = 0
+    packet.path = bytearray()
+    packet.payload = bytearray(ack_crc.to_bytes(4, "little"))
+    packet.payload_len = 4
+
+    handler = comp.node.dispatcher._get_handler(PAYLOAD_TYPE_ACK)
+    await handler(packet)
+
+    assert ack_crc not in comp._pending_ack_crcs, "pending entry must be cleared"
+    assert confirmed == [ack_crc], "send_confirmed must fire for the tracked CRC"
+    assert (
+        packet.is_marked_do_not_retransmit() is True
+    ), "companion-consumed ACK must be suppressed from client-repeat forwarding"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_waiter_stays_marked_when_listener_raises():
+    """Regression (review): marking a dispatcher-awaited ACK must not depend on
+    the listener call succeeding. The pre-change code marked BEFORE notifying;
+    that guarantee holds — a raising listener still leaves the packet marked
+    (the exception propagates to the caller as before).
+    """
+    ack_crc = 0x12345678
+    dispatcher = SimpleNamespace(
+        local_identity=LOCAL_IDENTITY,
+        contact_book=ContactStore(),
+        _waiting_acks={ack_crc: object()},  # a dispatcher-level waiter exists
+    )
+    handler = AckHandler(lambda _m: None, dispatcher)
+
+    async def raising_listener(crc):
+        raise RuntimeError("listener blew up")
+
+    handler.set_ack_received_callback(raising_listener)
+    packet = Packet()
+    packet.header = 1 << 2  # PAYLOAD_TYPE_ACK, route flood
+    packet.path_len = 0
+    packet.path = bytearray()
+    packet.payload = bytearray(ack_crc.to_bytes(4, "little"))
+    packet.payload_len = 4
+    with pytest.raises(RuntimeError):
+        await handler(packet)
+    assert (
+        packet.is_marked_do_not_retransmit() is True
+    ), "a dispatcher-awaited ACK must stay marked even when the listener fails"
 
 
 @pytest.mark.asyncio
@@ -431,3 +509,42 @@ async def test_decrypted_path_ack_is_authenticated_regardless_of_consumption(lis
     )
     assert notified == [ack_crc], "the embedded CRC must still reach the listener"
 
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize(
+    "result, expect_marked",
+    [(True, True), (False, False), (None, False)],
+)
+async def test_ack_received_listener_consumed_contract(is_async, result, expect_marked):
+    """Contract for AckReceivedCallback: a truthy return means the ACK matched one of this node's
+    pending sends (mark do-not-retransmit); False/None means not mine (leave it). Both sync and
+    async listeners honour it, and a None-returning listener stays backward-compatible."""
+    ack_crc = 0x0BADF00D
+    dispatcher = Dispatcher(_CallbackRadio())
+    dispatcher.local_identity = LOCAL_IDENTITY
+    dispatcher.set_contact_book(ContactStore())
+
+    if is_async:
+
+        async def listener(crc):
+            return result
+
+    else:
+
+        def listener(crc):
+            return result
+
+    dispatcher.set_ack_received_listener(listener)
+
+    handler = AckHandler(lambda _m: None, dispatcher)
+    handler.set_ack_received_callback(dispatcher._register_ack_received)
+
+    packet = Packet()
+    packet.header = 1 << 2  # PAYLOAD_TYPE_ACK, route flood
+    packet.path_len = 0
+    packet.path = bytearray()
+    packet.payload = bytearray(ack_crc.to_bytes(4, "little"))
+    packet.payload_len = 4
+    await handler(packet)
+    assert packet.is_marked_do_not_retransmit() is expect_marked


### PR DESCRIPTION
CompanionRadio tracks expected ACKs in its own pending table rather than `Dispatcher._waiting_acks`. Consequently, PATH-embedded ACKs could be ignored without a dispatcher waiter, while a consumed discrete ACK could remain eligible for client-repeat forwarding.

This change delivers every authenticated PATH ACK to the application listener and lets the listener report whether a discrete ACK matched an app-side send. MAC-verified PATH packets are consumed independently of CRC matching, matching MeshCore behavior. Existing notify-only listeners remain compatible, unknown discrete ACKs remain forwardable, and dispatcher-owned ACKs stay suppressed even if a listener raises.

Tests cover MeshCore PATH variants, real CompanionRadio wiring, consumed and unknown ACKs, synchronous/asynchronous/notify-only listeners, and listener-failure ordering.

Validation:
- Full test suite passed.
- `pre-commit run --all-files` passed.
