### PR TITLE
Reply scope fallback, direct-login out_path, and companion frame errors

### DIFF
--- a/examples/login_server.py
+++ b/examples/login_server.py
@@ -297,11 +297,25 @@ async def run_login_server(
     # Create ACL for managing authenticated clients
     acl = ClientACL(max_clients=32, admin_password=admin_password, guest_password=guest_password)
 
+    def get_out_path(client_identity: Identity):
+        client = acl.get_client(client_identity.get_public_key())
+        if client is None or client.out_path_len < 0:
+            return None
+        return (bytes(client.out_path), client.out_path_len)
+
+    def clear_out_path(client_identity: Identity):
+        client = acl.get_client(client_identity.get_public_key())
+        if client is not None:
+            client.out_path_len = -1
+            client.out_path = bytearray()
+
     # Create login server handler with authentication callback
     login_handler = LoginServerHandler(
         local_identity=identity,
         log_fn=lambda msg: print(msg),
         authenticate_callback=acl.authenticate_client,  # Delegate authentication to ACL
+        get_out_path=get_out_path,
+        clear_out_path=clear_out_path,
     )
 
     # Set up packet sending callback

--- a/src/openhop_core/companion/base_config.py
+++ b/src/openhop_core/companion/base_config.py
@@ -343,6 +343,14 @@ class _DeviceConfigMixin:
         request, or no key configured) so the dispatcher's node-level scope
         cannot override that decision.
         """
+        # Checked FIRST, as Dispatcher._apply_flood_scope does: a scope the
+        # reply helper already decided outranks this node's send state, and a
+        # reply deliberately left plain (chooseReplyScope NONE, mirroring an
+        # un-scoped request) must not be scoped here. Every call site below
+        # builds its packet immediately before calling this, so a fresh packet
+        # is never affected.
+        if getattr(pkt, "_flood_scope_applied", False):
+            return
         route_type = pkt.get_route_type()
         if route_type != ROUTE_TYPE_FLOOD:
             return  # only scope flood packets, not direct

--- a/src/openhop_core/companion/base_config.py
+++ b/src/openhop_core/companion/base_config.py
@@ -346,9 +346,13 @@ class _DeviceConfigMixin:
         # Checked FIRST, as Dispatcher._apply_flood_scope does: a scope the
         # reply helper already decided outranks this node's send state, and a
         # reply deliberately left plain (chooseReplyScope NONE, mirroring an
-        # un-scoped request) must not be scoped here. Every call site below
-        # builds its packet immediately before calling this, so a fresh packet
-        # is never affected.
+        # un-scoped request) must not be scoped here.
+        #
+        # The send paths are unaffected because each builds its packet
+        # immediately before calling this. Where that packet comes from a
+        # builder callable rather than an inline PacketBuilder call, the
+        # freshness this relies on is enforced rather than assumed -- see
+        # ``_SendOpsMixin._take_built_packet``.
         if getattr(pkt, "_flood_scope_applied", False):
             return
         route_type = pkt.get_route_type()

--- a/src/openhop_core/companion/base_send.py
+++ b/src/openhop_core/companion/base_send.py
@@ -612,7 +612,7 @@ class _SendOpsMixin:
             logger.error("Error sending raw data direct: %s", e)
             return SentResult(success=False)
 
-    async def send_raw_packet(self, priority: int, packet_bytes: bytes) -> bool:
+    async def send_raw_packet(self, priority: int, packet_bytes: bytes) -> SentResult:
         """Inject a fully-formed on-air packet for transmission (CMD_SEND_RAW_PACKET).
 
         Mirrors firmware ``MyMesh.cpp`` ``CMD_SEND_RAW_PACKET``: parse the raw
@@ -626,28 +626,28 @@ class _SendOpsMixin:
         currently ignored: the bridge's low-level send path
         (:meth:`_send_packet`) does not expose a prioritized TX queue.
 
-        Returns True if the packet parsed and was handed off for transmission,
-        False on parse failure or send error (the frame_server handler maps
-        False to ``ERR_CODE_TABLE_FULL``).
+        Returns a :class:`SentResult`. Parse failure is ``error="illegal_arg"``
+        (firmware ``releasePacket`` + ``ERR_CODE_ILLEGAL_ARG``); TX/queue full
+        is ``error="send_failed"`` (firmware ``ERR_CODE_TABLE_FULL``).
         """
         try:
             pkt = Packet()
             if not pkt.read_from(bytes(packet_bytes)):
-                return False
+                return SentResult(success=False, error="illegal_arg")
         except Exception as e:
             logger.warning("send_raw_packet: failed to parse packet: %s", e)
-            return False
+            return SentResult(success=False, error="illegal_arg")
         try:
             success = await self._send_packet(pkt, wait_for_ack=False)
             if success:
                 self.stats.record_tx(is_flood=False)
-            else:
-                self.stats.record_tx_error()
-            return success
+                return SentResult(success=True)
+            self.stats.record_tx_error()
+            return SentResult(success=False, error="send_failed")
         except Exception as e:
             logger.error("Error sending raw packet: %s", e)
             self.stats.record_tx_error()
-            return False
+            return SentResult(success=False, error="send_failed")
 
     async def send_trace_path(
         self,

--- a/src/openhop_core/companion/base_send.py
+++ b/src/openhop_core/companion/base_send.py
@@ -783,7 +783,7 @@ class _SendOpsMixin:
         """Send the first packet and return its metadata plus a waiter task."""
         deadline = time.monotonic() + total_timeout_s if total_timeout_s is not None else None
         try:
-            pkt, packet_tag = build_packet()
+            pkt, packet_tag = self._take_built_packet(build_packet)
             if response_tag_registered is not None and packet_tag is not None:
                 response_tag_registered(packet_tag)
             self._apply_flood_scope(pkt)
@@ -1219,7 +1219,7 @@ class _SendOpsMixin:
         deadline = time.monotonic() + total_timeout_s if total_timeout_s else None
         for attempt in range(DEFAULT_MAX_ATTEMPTS):
             if attempt == 0:
-                pkt, packet_tag = build_packet()
+                pkt, packet_tag = self._take_built_packet(build_packet)
             else:
                 pkt, packet_tag = self._build_retry_packet(build_packet, proxy, log_label)
             if response_tag_registered is not None and packet_tag is not None:
@@ -1246,6 +1246,48 @@ class _SendOpsMixin:
             if not result.get("timeout"):
                 break
         return result
+
+    @staticmethod
+    def _take_built_packet(
+        build_packet: Callable[[], tuple[Packet, Optional[int]]],
+    ) -> tuple[Packet, Optional[int]]:
+        """Invoke a request builder and hold it to its freshness contract.
+
+        Every send path here scopes the packet it has just built, and both
+        resolvers -- ``CompanionBase._apply_flood_scope`` and
+        ``Dispatcher._apply_flood_scope`` -- skip a packet that already carries a
+        decision. That skip is deliberate: it is what lets a reply keep the
+        region ``apply_reply_scope`` chose for it, and what lets a bridge's own
+        region survive its host repeater's resolver.
+
+        The cost is that the mark makes a *reused* packet indistinguishable from
+        a decided one. A builder that returned a cached packet rather than a new
+        one would hand its second caller a packet already marked by the first
+        attempt, and the retry would go out plain -- stranded at hop 0 on
+        precisely the scoped meshes that made the first attempt fail. Nothing
+        downstream can tell that apart from a legitimate decision, so it is
+        caught here, where the builder's contract lives.
+
+        ``_path_hash_mode_applied`` is checked for the same reason: it also
+        suppresses the dispatcher, and ``Packet.read_from`` clears both together
+        as one frame's worth of decisions.
+
+        Every builder in this module constructs through ``PacketBuilder``, so
+        this can only be tripped by a future edit to this file -- a programming
+        error, never radio traffic or application input, which is why it raises
+        rather than degrading the send.
+        """
+        pkt, tag = build_packet()
+        if pkt is not None and (
+            getattr(pkt, "_flood_scope_applied", False)
+            or getattr(pkt, "_path_hash_mode_applied", False)
+        ):
+            raise ValueError(
+                "request builder returned a packet that already carries send-time "
+                "decisions; build_packet must construct a new Packet per call, or "
+                "the retry it feeds will skip scoping and go out plain"
+            )
+        return pkt, tag
 
     def _build_retry_packet(
         self,
@@ -1293,14 +1335,14 @@ class _SendOpsMixin:
         """
         saved = getattr(proxy, "out_path_len", None)
         if saved is None or saved < 0:
-            return build_packet()  # already floods; nothing to force
+            return self._take_built_packet(build_packet)  # already floods; nothing to force
         try:
             proxy.out_path_len = -1
         except Exception as e:  # not a settable proxy: fall back to its own route
             logger.debug("[PATHDIAG] %s: cannot force flood retry: %s", log_label, e)
-            return build_packet()
+            return self._take_built_packet(build_packet)
         try:
-            pkt, tag = build_packet()
+            pkt, tag = self._take_built_packet(build_packet)
         finally:
             proxy.out_path_len = saved
         if pkt is not None and pkt.is_route_flood():

--- a/src/openhop_core/companion/companion_bridge.py
+++ b/src/openhop_core/companion/companion_bridge.py
@@ -209,12 +209,10 @@ class CompanionBridge(CompanionBase):
 
         # Region registry for reply-region capture. None by default so a
         # standalone bridge captures nothing (replies fall through to the
-        # dispatcher default). A host repeater points this at its dispatcher's
-        # region_map so incoming request regions are captured and mirrored onto
-        # replies. If the dispatcher captured a default before delegation, a
-        # second bridge capture preserves that per-packet snapshot.
+        # ordinary send precedence). A host repeater points this at its
+        # dispatcher's region_map so incoming request regions are captured and
+        # mirrored onto replies.
         self.region_map: Optional[RegionMap] = None
-        self.default_flood_transport_key: Optional[bytes] = None
 
         async def _handler_send_packet(pkt: Packet, wait_for_ack: bool = False) -> bool:
             return await self._packet_injector(pkt, wait_for_ack=wait_for_ack)
@@ -478,7 +476,7 @@ class CompanionBridge(CompanionBase):
         # Capture the region this request arrived under before the handler
         # builds any reply, so a flood reply is scoped to that region (or plain).
         # No-op when no RegionMap is configured (standalone bridge).
-        capture_recv_region(self.region_map, packet, default_key=self.default_flood_transport_key)
+        capture_recv_region(self.region_map, packet)
 
         handler = self._handlers.get(ptype)
         if handler:

--- a/src/openhop_core/companion/companion_bridge.py
+++ b/src/openhop_core/companion/companion_bridge.py
@@ -17,7 +17,7 @@ from ..node.handlers import create_core_handlers
 from ..node.handlers.crypto_helpers import iter_decrypt_by_src_hash
 from ..node.handlers.login_server import LoginServerHandler
 from ..node.handlers.result import HandlerResult
-from ..protocol import LocalIdentity, Packet
+from ..protocol import Identity, LocalIdentity, Packet
 from ..protocol.constants import (
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
@@ -208,10 +208,13 @@ class CompanionBridge(CompanionBase):
         self._packet_injector = packet_injector
 
         # Region registry for reply-region capture. None by default so a
-        # standalone bridge captures nothing (replies fall through to plain). The
-        # host repeater points this at its dispatcher's region_map so incoming
-        # request regions are captured and mirrored onto replies.
+        # standalone bridge captures nothing (replies fall through to the
+        # dispatcher default). A host repeater points this at its dispatcher's
+        # region_map so incoming request regions are captured and mirrored onto
+        # replies. If the dispatcher captured a default before delegation, a
+        # second bridge capture preserves that per-packet snapshot.
         self.region_map: Optional[RegionMap] = None
+        self.default_flood_transport_key: Optional[bytes] = None
 
         async def _handler_send_packet(pkt: Packet, wait_for_ack: bool = False) -> bool:
             return await self._packet_injector(pkt, wait_for_ack=wait_for_ack)
@@ -251,8 +254,22 @@ class CompanionBridge(CompanionBase):
 
             auth_cb = _reject_all
 
+        def _get_login_out_path(client_identity: Identity) -> Optional[tuple[bytes, int]]:
+            contact = self.contacts.get_by_key(client_identity.get_public_key())
+            if contact is None or contact.out_path_len < 0:
+                return None
+            return (bytes(contact.out_path or b""), contact.out_path_len)
+
+        def _clear_login_out_path(client_identity: Identity) -> None:
+            self.reset_path(client_identity.get_public_key())
+
         login_server_handler = LoginServerHandler(
-            identity, _log, authenticate_callback=auth_cb, is_room_server=False
+            identity,
+            _log,
+            authenticate_callback=auth_cb,
+            is_room_server=False,
+            get_out_path=_get_login_out_path,
+            clear_out_path=_clear_login_out_path,
         )
         login_server_handler.set_send_packet_callback(_login_send_callback)
 
@@ -461,7 +478,7 @@ class CompanionBridge(CompanionBase):
         # Capture the region this request arrived under before the handler
         # builds any reply, so a flood reply is scoped to that region (or plain).
         # No-op when no RegionMap is configured (standalone bridge).
-        capture_recv_region(self.region_map, packet)
+        capture_recv_region(self.region_map, packet, default_key=self.default_flood_transport_key)
 
         handler = self._handlers.get(ptype)
         if handler:

--- a/src/openhop_core/companion/frame_server/commands_messaging.py
+++ b/src/openhop_core/companion/frame_server/commands_messaging.py
@@ -606,14 +606,18 @@ class _MessagingCommandsMixin:
         """Handle CMD_SEND_RAW_DATA (25).
         Format: [path_len_encoded][path][payload] (min 4-byte payload).
 
-        Firmware (MyMesh.cpp handleCmdFrame): `len >= 6` (len includes the
-        command byte, so the stripped `data` here only needs the path_len
-        byte to be present) then `path_len >= 0 && i + path_len + 4 <= len`,
-        which is exactly `1 + path_byte_len + 4 <= len(data)` below. A
-        zero-hop frame (path_len=0, 4-byte payload -> len(data) == 5) is the
-        firmware minimum and must not be rejected here.
+        Firmware (MyMesh.cpp handleCmdFrame, `dev` / 0cce9197):
+        - Frame never enters the branch (`len < 6`, command byte included) →
+          catch-all ``ERR_CODE_UNSUPPORTED_CMD``.
+        - Invalid encoded ``path_len`` → ``ERR_CODE_UNSUPPORTED_CMD``.
+        - Valid path, then remaining payload (or path bytes) short of 4 →
+          ``ERR_CODE_ILLEGAL_ARG`` (``writePath`` then ``i + 4 > len``).
+
+        ``data`` is command-stripped, so ``len(data) < 5`` is the ``len < 6``
+        case. A zero-hop frame (path_len=0, 4-byte payload → len(data) == 5)
+        is the firmware minimum and must not be rejected here.
         """
-        if len(data) < 1:
+        if len(data) < 5:
             self._write_err(ERR_CODE_UNSUPPORTED_CMD)
             return
         path_len_byte = data[0]
@@ -622,7 +626,7 @@ class _MessagingCommandsMixin:
             return
         path_byte_len = PathUtils.get_path_byte_len(path_len_byte)
         if 1 + path_byte_len + 4 > len(data):
-            self._write_err(ERR_CODE_UNSUPPORTED_CMD)
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
             return
         path = data[1 : 1 + path_byte_len]
         payload = data[1 + path_byte_len :]
@@ -650,12 +654,17 @@ class _MessagingCommandsMixin:
             self._write_err(ERR_CODE_UNSUPPORTED_CMD)
             return
         try:
-            ok = await send_raw_packet(priority, packet_bytes)
+            result = await send_raw_packet(priority, packet_bytes)
         except Exception as e:
             logger.error("send_raw_packet error: %s", e, exc_info=True)
             self._write_err(ERR_CODE_ILLEGAL_ARG)
             return
-        if ok:
+        # Firmware: tryParsePacket fail → releasePacket + ILLEGAL_ARG;
+        # obtainNewPacket fail / send fail → TABLE_FULL.
+        if result is True or getattr(result, "success", False):
             self._write_ok()
+            return
+        if getattr(result, "error", None) == "illegal_arg":
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
         else:
             self._write_err(ERR_CODE_TABLE_FULL)

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -591,7 +591,7 @@ class Dispatcher:
         # Capture the region this packet arrived under before any handler
         # runs, so a reply builder can scope its reply to that region. No-op when
         # no RegionMap is configured (standalone node/companion).
-        capture_recv_region(self.region_map, pkt, default_key=self.default_flood_transport_key)
+        capture_recv_region(self.region_map, pkt)
 
         # Let the node know about this packet for analysis (statistics, caching, etc.)
         if self.packet_analysis_callback:

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -591,7 +591,7 @@ class Dispatcher:
         # Capture the region this packet arrived under before any handler
         # runs, so a reply builder can scope its reply to that region. No-op when
         # no RegionMap is configured (standalone node/companion).
-        capture_recv_region(self.region_map, pkt)
+        capture_recv_region(self.region_map, pkt, default_key=self.default_flood_transport_key)
 
         # Let the node know about this packet for analysis (statistics, caching, etc.)
         if self.packet_analysis_callback:

--- a/src/openhop_core/node/handlers/login_server.py
+++ b/src/openhop_core/node/handlers/login_server.py
@@ -16,7 +16,12 @@ import time
 from typing import Callable, Optional
 
 from ...protocol import CryptoUtils, Identity, Packet, PacketBuilder, PathUtils
-from ...protocol.constants import PAYLOAD_TYPE_ANON_REQ, PAYLOAD_TYPE_RESPONSE, acl_is_admin
+from ...protocol.constants import (
+    MAX_PATH_SIZE,
+    PAYLOAD_TYPE_ANON_REQ,
+    PAYLOAD_TYPE_RESPONSE,
+    acl_is_admin,
+)
 from ...protocol.region_map import apply_reply_scope
 from .base import BaseHandler
 from .result import HandlerResult
@@ -66,6 +71,8 @@ class LoginServerHandler(BaseHandler):
         log_fn: Callable[[str], None],
         authenticate_callback: Callable[[Identity, bytes, str, int], tuple[bool, int]],
         is_room_server: bool = False,
+        get_out_path: Optional[Callable[[Identity], Optional[tuple[bytes, int]]]] = None,
+        clear_out_path: Optional[Callable[[Identity], None]] = None,
     ):
         """
         Initialize login server handler.
@@ -80,16 +87,51 @@ class LoginServerHandler(BaseHandler):
                                    (see PERM_ACL_* in protocol.constants).
             is_room_server: True if this identity is a room server (expects sync_since field),
                            False if repeater (no sync_since field)
+            get_out_path: Optional ACL lookup ``identity -> (path_bytes, path_len_encoded)``
+                          or ``None`` when no stored path. Used for DIRECT login replies
+                          (firmware #3106 / ``chooseReplyRoute`` ``DIRECT_OUT_PATH``).
+                          Login ANON_REQ does not carry a supplied reply path.
+            clear_out_path: Optional ACL callback invoked on a successful flood login
+                            (firmware ``handleLoginReq`` sets ``OUT_PATH_UNKNOWN``).
         """
         self.local_identity = local_identity
         self.log = log_fn
         self.authenticate = authenticate_callback
         self.is_room_server = is_room_server
+        self.get_out_path = get_out_path
+        self.clear_out_path = clear_out_path
         self._send_packet_callback: Optional[Callable[[Packet, int], None]] = None
 
     def set_send_packet_callback(self, callback: Callable[[Packet, int], None]):
         """Set callback for sending response packets."""
         self._send_packet_callback = callback
+
+    def _lookup_out_path(self, client_identity: Identity) -> Optional[tuple[bytes, int]]:
+        """Return a stored ACL out_path if the app provided a usable one."""
+        if self.get_out_path is None:
+            return None
+        try:
+            result = self.get_out_path(client_identity)
+            if not result:
+                return None
+            path_bytes, raw_path_len = result
+            path_len_encoded = int(raw_path_len)
+            if path_len_encoded < 0 or not PathUtils.is_valid_path_len(path_len_encoded):
+                return None
+            path_bytes = bytes(path_bytes or b"")
+            expected = PathUtils.get_path_byte_len(path_len_encoded)
+            if len(path_bytes) < expected:
+                self.log(
+                    f"[LoginServer] Stored out_path is {len(path_bytes)}B but path_len "
+                    f"0x{path_len_encoded:02X} declares {expected}B; flooding instead"
+                )
+                return None
+            return (path_bytes[:expected], path_len_encoded)
+        except Exception as e:
+            # An application-owned ACL entry must never suppress the reply. If
+            # its path cannot be normalized, use the firmware's FLOOD fallback.
+            self.log(f"[LoginServer] Unusable stored out_path ({e}); flooding instead")
+            return None
 
     async def __call__(self, packet: Packet) -> HandlerResult:
         """Handle ANON_REQ login packet from client.
@@ -274,12 +316,18 @@ class LoginServerHandler(BaseHandler):
             struct.pack_into("<I", reply_data, 8, random.randint(0, 0xFFFFFFFF))  # random blob
             reply_data[12] = FIRMWARE_VER_LEVEL  # firmware version
 
-            # Create response packet
-            # Match C++ simple_repeater behavior:
-            # - Flood login: send PATH packet with response as extra data
-            #   (tells sender the path TO here so they can sendDirect)
-            # - Direct login: send regular RESPONSE datagram via flood
+            # Firmware chooseReplyRoute (repeater + room-server #3106):
+            # - Flood login → PATH return (and clear stored out_path).
+            # - Direct + stored ACL out_path → sendDirect along that path.
+            # - Direct + no path → flood RESPONSE. Login ANON_REQ does not
+            #   carry a supplied reply path (DIRECT_SUPPLIED is N/A).
             if is_flood:
+                if self.clear_out_path is not None:
+                    try:
+                        self.clear_out_path(client_identity)
+                    except Exception as e:
+                        self.log(f"[LoginServer] clear_out_path failed: {e}")
+
                 client_hash = client_identity.get_public_key()[0]
                 server_hash = self.local_identity.get_public_key()[0]
                 path_list = (
@@ -310,34 +358,49 @@ class LoginServerHandler(BaseHandler):
                 )
                 packet_type_name = "PATH"
             else:
-                # Direct login: send regular RESPONSE datagram via flood
-                # (like C++ simple_repeater when reply_path_len < 0)
-                response_pkt = PacketBuilder.create_datagram(
-                    ptype=PAYLOAD_TYPE_RESPONSE,
-                    dest=client_identity,
-                    local_identity=self.local_identity,
-                    secret=shared_secret,
-                    plaintext=bytes(reply_data),
-                    route_type="flood",
-                )
-                packet_type_name = "RESPONSE(flood)"
-                self.log("[LoginServer] Creating RESPONSE datagram (direct login, flood reply)")
+                stored = self._lookup_out_path(client_identity)
+                if stored is not None:
+                    path_bytes, path_len_encoded = stored
+                    response_pkt = PacketBuilder.create_datagram(
+                        ptype=PAYLOAD_TYPE_RESPONSE,
+                        dest=client_identity,
+                        local_identity=self.local_identity,
+                        secret=shared_secret,
+                        plaintext=bytes(reply_data),
+                        route_type="direct",
+                    )
+                    response_pkt.set_path(path_bytes[:MAX_PATH_SIZE], path_len_encoded)
+                    packet_type_name = "RESPONSE(direct)"
+                    self.log(
+                        "[LoginServer] Creating RESPONSE datagram "
+                        "(direct login, stored out_path)"
+                    )
+                else:
+                    response_pkt = PacketBuilder.create_datagram(
+                        ptype=PAYLOAD_TYPE_RESPONSE,
+                        dest=client_identity,
+                        local_identity=self.local_identity,
+                        secret=shared_secret,
+                        plaintext=bytes(reply_data),
+                        route_type="flood",
+                    )
+                    packet_type_name = "RESPONSE(flood)"
+                    self.log(
+                        "[LoginServer] Creating RESPONSE datagram " "(direct login, flood reply)"
+                    )
 
-            # Accumulate the reply's path at the *request's* hash width, not this
-            # node's own preference. Firmware sends both branches through
-            # sendFloodReply(..., packet->getPathHashSize()) (simple_repeater
-            # onAnonDataRecv); the node's path_hash_mode governs only packets it
-            # originates itself (sendFloodScoped(default_scope, ..., _prefs
-            # .path_hash_mode + 1)). Marked applied so the dispatcher's node
-            # default cannot stamp over the mirror, the same way apply_reply_scope
-            # protects the region decision below.
-            in_path_len = getattr(original_packet, "path_len", 0) if original_packet else 0
-            in_hash_size = (
-                PathUtils.get_path_hash_size(in_path_len)
-                if PathUtils.is_valid_path_len(in_path_len)
-                else 1
-            )
-            response_pkt.apply_path_hash_mode(in_hash_size - 1, mark_applied=True)
+            if response_pkt.is_route_flood():
+                # Accumulate the flood reply at the *request's* hash width.
+                # Firmware sendFloodReply(..., packet->getPathHashSize()).
+                # The direct/out_path branch keeps the stored path_len.
+                in_path_len = getattr(original_packet, "path_len", 0) if original_packet else 0
+                in_hash_size = (
+                    PathUtils.get_path_hash_size(in_path_len)
+                    if PathUtils.is_valid_path_len(in_path_len)
+                    else 1
+                )
+                response_pkt.apply_path_hash_mode(in_hash_size - 1, mark_applied=True)
+                apply_reply_scope(response_pkt, original_packet)
 
             # Debug: Log packet details
             self.log(
@@ -347,12 +410,6 @@ class LoginServerHandler(BaseHandler):
                 f"path_len={response_pkt.path_len}, "
                 f"payload[0:2]={bytes(response_pkt.payload[:2]).hex()}"
             )
-
-            # Scope the flood reply (PATH-return for a flood login, or the flood
-            # RESPONSE datagram for a direct login) to the region the request
-            # arrived under. Both branches build a flood reply; a direct request
-            # captures no region and stays plain.
-            apply_reply_scope(response_pkt, original_packet)
 
             # Send with delay (matches C++ SERVER_RESPONSE_DELAY)
             delay_ms = 300

--- a/src/openhop_core/node/handlers/protocol_request.py
+++ b/src/openhop_core/node/handlers/protocol_request.py
@@ -390,14 +390,11 @@ class ProtocolRequestHandler:
                     else 1
                 )
                 reply_packet.apply_path_hash_mode(in_hash_size - 1, mark_applied=True)
-                # No out_path, so this RESPONSE floods. Firmware sends it via
-                # sendFloodReply (simple_repeater onPeerDataRecv, the
-                # OUT_PATH_UNKNOWN branch), which for a DIRECT request means
-                # recv_pkt_region is NULL => plain, unscoped flood. Decide it
-                # here so the dispatcher's node default/override cannot stamp a
-                # region firmware would never put on this reply. On a node with
-                # no RegionMap this is inert and the reply falls through to the
-                # node default, matching BaseChatMesh's sendFloodScoped(from).
+                # No out_path, so this RESPONSE floods via sendFloodReply.
+                # chooseReplyScope: unscoped flood → plain; DIRECT / unresolved
+                # → DEFAULT when a default region is configured, else plain.
+                # On a node with no RegionMap this is inert and the reply falls
+                # through to the node default (BaseChatMesh sendFloodScoped).
                 apply_reply_scope(reply_packet, original_packet)
 
             self.log(f"RESPONSE built for 0x{client_hash:02X} via {route_type.upper()}")

--- a/src/openhop_core/node/handlers/protocol_request.py
+++ b/src/openhop_core/node/handlers/protocol_request.py
@@ -391,10 +391,12 @@ class ProtocolRequestHandler:
                 )
                 reply_packet.apply_path_hash_mode(in_hash_size - 1, mark_applied=True)
                 # No out_path, so this RESPONSE floods via sendFloodReply.
-                # chooseReplyScope: unscoped flood → plain; DIRECT / unresolved
-                # → DEFAULT when a default region is configured, else plain.
-                # On a node with no RegionMap this is inert and the reply falls
-                # through to the node default (BaseChatMesh sendFloodScoped).
+                # chooseReplyScope: an unscoped-flood request is mirrored plain
+                # and marked final here. A DIRECT or unresolved request is
+                # REPLY_SCOPE_DEFAULT, which is left to the send layer -- as is
+                # a node with no RegionMap at all, where this is simply inert.
+                # Either way the ordinary precedence supplies the key
+                # (BaseChatMesh sendFloodScoped).
                 apply_reply_scope(reply_packet, original_packet)
 
             self.log(f"RESPONSE built for 0x{client_hash:02X} via {route_type.upper()}")

--- a/src/openhop_core/node/handlers/text.py
+++ b/src/openhop_core/node/handlers/text.py
@@ -159,8 +159,10 @@ class TextMessageHandler(BaseHandler):
             )
             # Firmware sends the flood PATH-return (carrying the ACK) via
             # sendFloodScoped(from, path, TXT_ACK_DELAY): scope the reply to the
-            # region the request arrived under, decided synchronously here from
-            # the request packet before the delayed send task runs.
+            # region the request arrived under. Read synchronously from the
+            # request packet, before the delayed send task runs, because the
+            # capture lives on that Packet. A request whose scope is unknowable
+            # is REPLY_SCOPE_DEFAULT and resolves at send time instead.
             apply_reply_scope(ack_packet, packet)
             self.log(f"FLOOD ACK timing - delay:{TXT_ACK_DELAY_MS}ms")
             return [(ack_packet, TXT_ACK_DELAY_MS / 1000.0)]

--- a/src/openhop_core/protocol/__init__.py
+++ b/src/openhop_core/protocol/__init__.py
@@ -89,6 +89,7 @@ from .region_map import (
     RegionMap,
     apply_reply_scope,
     capture_recv_region,
+    choose_reply_scope,
 )
 from .transport_keys import calc_transport_code, get_auto_key_for, scope_packet
 from .utils import decode_appdata, is_self_advert, parse_advert_payload
@@ -109,6 +110,7 @@ __all__ = [
     "REGION_DENY_DIRECT",
     "capture_recv_region",
     "apply_reply_scope",
+    "choose_reply_scope",
     # Utility functions
     "parse_advert_payload",
     "decode_appdata",

--- a/src/openhop_core/protocol/packet.py
+++ b/src/openhop_core/protocol/packet.py
@@ -122,7 +122,6 @@ class Packet:
         "_recv_region_captured",
         "_recv_region_key",
         "_recv_region_unscoped",
-        "_recv_default_scope_key",
     )
 
     def __init__(self):
@@ -156,16 +155,15 @@ class Packet:
         # the repeater inject path so the companion fan-out can withhold the packet
         # from its own sender -- a node never hears its own transmission.
         self._injected_origin_hash: Optional[str] = None
-        # Region captured from this packet on receive. Only set True when
-        # a RegionMap was actually consulted; the matched region key (or None)
-        # plus the snapshotted default key are read by region_map.apply_reply_scope
-        # when a handler builds a flood reply (chooseReplyScope REQUEST / DEFAULT /
+        # Region captured from this packet on receive. Only set True when a
+        # RegionMap was actually consulted; the matched region key (or None) and
+        # the un-scoped flag are read by region_map.apply_reply_scope when a
+        # handler builds a flood reply (chooseReplyScope REQUEST / DEFAULT /
         # NONE). Lives on the Packet, never a shared dispatcher member, because
         # replies are sent from background tasks that would race.
         self._recv_region_captured: bool = False
         self._recv_region_key: Optional[bytes] = None
         self._recv_region_unscoped: bool = False
-        self._recv_default_scope_key: Optional[bytes] = None
 
     def get_route_type(self) -> int:
         """

--- a/src/openhop_core/protocol/packet.py
+++ b/src/openhop_core/protocol/packet.py
@@ -471,6 +471,20 @@ class Packet:
             ValueError: If the packet format is invalid, truncated, or contains
                 invalid values (e.g., path_len too large, invalid payload size).
         """
+        # A Packet object may be reused across frames (pooling, or an app
+        # parsing into a scratch packet). Every field below describes a decision
+        # about *this* frame, so none of the previous frame's may survive into
+        # it: a stale _recv_region_* would have the next reply mirror the wrong
+        # region, and a stale _flood_scope_applied / _path_hash_mode_applied
+        # would make both send-layer resolvers skip a packet they have never
+        # seen. The dispatcher's own RX builds a fresh Packet, so this is a
+        # guard on the public API rather than a fix to a shipped path.
+        self._recv_region_captured = False
+        self._recv_region_key = None
+        self._recv_region_unscoped = False
+        self._flood_scope_applied = False
+        self._path_hash_mode_applied = False
+
         idx, data_len = 0, len(data)
         self.header = data[idx]
         idx += 1

--- a/src/openhop_core/protocol/packet.py
+++ b/src/openhop_core/protocol/packet.py
@@ -121,6 +121,8 @@ class Packet:
         "_injected_origin_hash",
         "_recv_region_captured",
         "_recv_region_key",
+        "_recv_region_unscoped",
+        "_recv_default_scope_key",
     )
 
     def __init__(self):
@@ -155,12 +157,15 @@ class Packet:
         # from its own sender -- a node never hears its own transmission.
         self._injected_origin_hash: Optional[str] = None
         # Region captured from this packet on receive. Only set True when
-        # a RegionMap was actually consulted; the matched region key (or None =>
-        # reply plain) is read by region_map.apply_reply_scope when a handler
-        # builds a flood reply. Lives on the Packet, never a shared dispatcher
-        # member, because replies are sent from background tasks that would race.
+        # a RegionMap was actually consulted; the matched region key (or None)
+        # plus the snapshotted default key are read by region_map.apply_reply_scope
+        # when a handler builds a flood reply (chooseReplyScope REQUEST / DEFAULT /
+        # NONE). Lives on the Packet, never a shared dispatcher member, because
+        # replies are sent from background tasks that would race.
         self._recv_region_captured: bool = False
         self._recv_region_key: Optional[bytes] = None
+        self._recv_region_unscoped: bool = False
+        self._recv_default_scope_key: Optional[bytes] = None
 
     def get_route_type(self) -> int:
         """

--- a/src/openhop_core/protocol/region_map.py
+++ b/src/openhop_core/protocol/region_map.py
@@ -195,15 +195,23 @@ def capture_recv_region(region_map: Optional[RegionMap], pkt: Packet) -> None:
     """
     if region_map is None:
         return
-    if getattr(pkt, "_recv_region_captured", False):
+    if getattr(pkt, "_recv_region_captured", False) and (
+        getattr(pkt, "_recv_region_key", None) is not None
+        or getattr(pkt, "_recv_region_unscoped", False)
+    ):
         # Firmware captures ``recv_pkt_region`` exactly once, in onRecvPacket,
         # and every later consumer reads that one decision. Here a Packet can
         # reach two entrypoints -- the dispatcher, then a CompanionBridge the
         # host delegates it to -- with awaits and flood hold time in between,
         # during which the shared RegionMap can be rebuilt (the repeater
-        # hot-reloads it on a transport-key change). Keep the first capture: it
-        # is the one taken against the map that was live when the packet
-        # actually arrived.
+        # hot-reloads it on a transport-key change). Keep a capture that reached
+        # a decision: it was taken against the map that was live when the packet
+        # actually arrived, and re-running it against a newer map would silently
+        # replace a correct answer with a worse one.
+        #
+        # A capture that resolved *nothing* is not a decision, so it does not
+        # block a second entrypoint whose own RegionMap may resolve the code --
+        # a bridge is free to serve regions its host dispatcher does not.
         return
     pkt._recv_region_captured = True
     pkt._recv_region_unscoped = False

--- a/src/openhop_core/protocol/region_map.py
+++ b/src/openhop_core/protocol/region_map.py
@@ -195,6 +195,16 @@ def capture_recv_region(region_map: Optional[RegionMap], pkt: Packet) -> None:
     """
     if region_map is None:
         return
+    if getattr(pkt, "_recv_region_captured", False):
+        # Firmware captures ``recv_pkt_region`` exactly once, in onRecvPacket,
+        # and every later consumer reads that one decision. Here a Packet can
+        # reach two entrypoints -- the dispatcher, then a CompanionBridge the
+        # host delegates it to -- with awaits and flood hold time in between,
+        # during which the shared RegionMap can be rebuilt (the repeater
+        # hot-reloads it on a transport-key change). Keep the first capture: it
+        # is the one taken against the map that was live when the packet
+        # actually arrived.
+        return
     pkt._recv_region_captured = True
     pkt._recv_region_unscoped = False
     route_type = pkt.get_route_type()

--- a/src/openhop_core/protocol/region_map.py
+++ b/src/openhop_core/protocol/region_map.py
@@ -166,91 +166,111 @@ def choose_reply_scope(
     return REPLY_SCOPE_NONE
 
 
-def capture_recv_region(
-    region_map: Optional[RegionMap],
-    pkt: Packet,
-    default_key: Optional[bytes] = None,
-) -> None:
+def capture_recv_region(region_map: Optional[RegionMap], pkt: Packet) -> None:
     """Record the region a received packet arrived under, onto the packet.
 
     Shared by both RX entrypoints (``Dispatcher._process_received_packet`` and
     ``CompanionBridge.process_received_packet``) so capture is identical.
-    Mirrors firmware ``recv_pkt_region`` capture:
+    Mirrors firmware ``recv_pkt_region`` capture, which distinguishes three
+    outcomes rather than two:
 
     - ``TRANSPORT_FLOOD``: match against ``REGION_DENY_FLOOD``-honouring regions
-      and record that region's (single) key.
-    - ``FLOOD``: record whether the wildcard permits it. An allowed wildcard
-      mirrors the request as unscoped; a denied wildcard falls back to DEFAULT.
-    - Direct or unresolved transport scope: fall back to ``default_key``.
+      and record that region's (single) key. Firmware tests ``isWildcard()`` on
+      the match before resolving any key. Its ``findMatch`` iterates the region
+      list only and so cannot return the wildcard -- ids are handed out from
+      ``next_id``, so nothing in ``regions[]`` has id 0 -- but nothing here stops
+      an application registering a RegionEntry with id 0, so honour the same
+      precedence rather than scoping a reply firmware would have sent plain.
+    - ``FLOOD``: firmware sets ``recv_pkt_region = &getWildcard()`` unless the
+      wildcard denies flood. Recorded as ``_recv_region_unscoped`` -- the
+      requester chose un-scoped, and :func:`apply_reply_scope` mirrors it.
+    - Direct, an unresolved transport code, a region with no usable key, or a
+      wildcard that denies flood: firmware leaves ``recv_pkt_region`` NULL, which
+      is *scope unknowable* rather than *un-scoped*. Both flags stay clear and
+      the reply defers to the ordinary send precedence.
 
-    A ``None`` region_map (standalone companion) is a no-op: ``_recv_region_captured``
-    stays False, so a reply falls through to the dispatcher default.
+    A ``None`` region_map (standalone node/companion) is a no-op:
+    ``_recv_region_captured`` stays False, so a reply falls through to that same
+    precedence.
     """
     if region_map is None:
         return
-    if default_key is None and getattr(pkt, "_recv_region_captured", False):
-        # The host dispatcher may already have captured a valid default before
-        # handing this same Packet to a CompanionBridge. Do not erase that
-        # snapshot merely because the bridge has no duplicate key configured.
-        default_key = getattr(pkt, "_recv_default_scope_key", None)
     pkt._recv_region_captured = True
-    pkt._recv_default_scope_key = default_key
     pkt._recv_region_unscoped = False
-    if pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD:
+    route_type = pkt.get_route_type()
+    if route_type == ROUTE_TYPE_TRANSPORT_FLOOD:
         entry = region_map.find_match(pkt, mask=REGION_DENY_FLOOD)
         if entry is not None and entry.is_wildcard():
             pkt._recv_region_key = None
             pkt._recv_region_unscoped = True
         else:
             pkt._recv_region_key = region_map.first_key_for(entry)
-    elif pkt.get_route_type() == ROUTE_TYPE_FLOOD:
+    elif route_type == ROUTE_TYPE_FLOOD:
         pkt._recv_region_key = None
         pkt._recv_region_unscoped = not (region_map.wildcard.flags & REGION_DENY_FLOOD)
     else:
         pkt._recv_region_key = None
 
 
-def apply_reply_scope(
-    reply_pkt: Packet,
-    request_pkt: Optional[Packet],
-    default_key: Optional[bytes] = None,
-) -> None:
+def apply_reply_scope(reply_pkt: Packet, request_pkt: Optional[Packet]) -> None:
     """Scope a freshly-built flood reply per firmware ``chooseReplyScope``.
 
-    Re-hashes the transport code over the reply's own payload — never the
-    request's code.
+    Re-hashes the transport code over the reply's own payload -- never copies
+    the request's code.
 
-    - Not captured (standalone companion, ``region_map`` None): return without
-      marking, so the reply falls through to the dispatcher default.
-    - Captured + known request region: REQUEST (scope with that key).
-    - Captured + unscoped flood: NONE (plain, marked so a node default cannot
-      override the requester's choice).
-    - Captured + direct / unresolved region: DEFAULT if a default key is
-      available (argument or snapshotted at capture), else NONE (plain).
+    - Not captured (standalone node, ``region_map`` None): return unmarked, so
+      the reply falls through to the ordinary send precedence.
+    - ``REPLY_SCOPE_REQUEST`` -- captured with a key: scope the reply with it and
+      mark the decision final.
+    - ``REPLY_SCOPE_NONE`` -- the request arrived as an un-scoped flood: mirror
+      that and mark it final, so a node default cannot scope a reply on a path
+      that demonstrably works un-scoped today.
+    - ``REPLY_SCOPE_DEFAULT`` -- the request's scope is unknowable (it arrived
+      DIRECT and so carried no transport codes, or its code matched no Region):
+      return unmarked and let the send layer resolve it.
 
-    In every captured case the reply is marked ``_flood_scope_applied`` so the
-    dispatcher's node-default scope cannot override this decision.
+    Only the first two decisions set ``_flood_scope_applied``. That mark exists
+    to stop the node default reaching a reply whose scope *this* helper decided,
+    so the deferring case must not set it.
+
+    Why DEFAULT defers instead of scoping here. Firmware splits this case by
+    role: a repeater resolves it as ``sendFloodScoped(default_scope, ...)``
+    (``simple_repeater/MyMesh.cpp``), while a companion answers the same case
+    with ``sendFloodScoped(recipient, ...)``, which is ``send_unscoped`` first,
+    then ``send_scope``, else ``default_scope``
+    (``companion_radio/MyMesh.cpp``). One helper here serves both roles, and
+    ``Dispatcher._apply_flood_scope`` / ``CompanionBase._apply_flood_scope``
+    already implement exactly that precedence -- including firmware's final
+    ``REPLY_SCOPE_NONE``, since a node with no scope configured at all leaves the
+    packet a plain flood. Deciding here would duplicate that chain and, by
+    marking the packet, suppress it: an operator's explicit-unscoped flag and
+    transient override would both be silently overridden. It would also bind the
+    reply to the default as it stood at RX rather than at TX.
+
+    Replying un-scoped in this case is the bug MeshCore PR #3106 fixed: a
+    repeater on the way back running ``flood.max.unscoped=0`` drops such a reply
+    at hop 0. The fix is that a configured default now reaches it -- which it
+    does through the send layer.
     """
     if not getattr(request_pkt, "_recv_region_captured", False):
         return
     req_key = getattr(request_pkt, "_recv_region_key", None)
-    if default_key is None:
-        default_key = getattr(request_pkt, "_recv_default_scope_key", None)
     scope = choose_reply_scope(
         req_key is not None,
         bool(getattr(request_pkt, "_recv_region_unscoped", False)),
-        default_key is not None,
+        # This third input is the send layer's to answer, and it resolves
+        # DEFAULT and the no-default NONE identically, from the configuration
+        # current at TX. Passing True asks for that deferred outcome; it is not
+        # a claim that a default is configured.
+        default_scope_known=True,
     )
-    if (
-        scope == REPLY_SCOPE_REQUEST
-        and req_key is not None
-        and reply_pkt.get_route_type() == ROUTE_TYPE_FLOOD
-    ):
-        scope_packet(reply_pkt, req_key)
-    elif (
-        scope == REPLY_SCOPE_DEFAULT
-        and default_key is not None
-        and reply_pkt.get_route_type() == ROUTE_TYPE_FLOOD
-    ):
-        scope_packet(reply_pkt, default_key)
-    reply_pkt._flood_scope_applied = True
+    if scope == REPLY_SCOPE_REQUEST:
+        if reply_pkt.get_route_type() == ROUTE_TYPE_FLOOD:
+            scope_packet(reply_pkt, req_key)
+        reply_pkt._flood_scope_applied = True
+        return
+    if scope == REPLY_SCOPE_NONE:
+        # Un-scoped flood request: leave the reply plain, decision final.
+        reply_pkt._flood_scope_applied = True
+        return
+    # REPLY_SCOPE_DEFAULT: leave unmarked for the send layer.

--- a/src/openhop_core/protocol/region_map.py
+++ b/src/openhop_core/protocol/region_map.py
@@ -13,6 +13,11 @@ from .transport_keys import calc_transport_code, get_auto_key_for, scope_packet
 REGION_DENY_FLOOD = 0x01
 REGION_DENY_DIRECT = 0x02  # reserved for future use
 
+# Firmware helpers/RoutingPolicy.h ReplyScope
+REPLY_SCOPE_REQUEST = "request"
+REPLY_SCOPE_DEFAULT = "default"
+REPLY_SCOPE_NONE = "none"
+
 
 @dataclass
 class RegionEntry:
@@ -24,12 +29,20 @@ class RegionEntry:
     name: str = ""
     private_keys: Optional[List[bytes]] = None
 
+    def is_wildcard(self) -> bool:
+        """Return whether this is firmware's root/wildcard region."""
+        return self.id == 0
+
 
 class RegionMap:
     """In-memory region registry with packet→region matching."""
 
     def __init__(self, regions: Optional[Iterable[RegionEntry]] = None) -> None:
         self._regions: list[RegionEntry] = list(regions or [])
+        # Firmware keeps the wildcard outside its ordinary region array. A
+        # plain FLOOD arrived under this region only when it allows flooding;
+        # when denied, reply scope is unknowable and falls back to DEFAULT.
+        self.wildcard = RegionEntry(id=0, parent=0, flags=0, name="*")
 
     # ------------------------------------------------------------------
     # Basic CRUD
@@ -133,7 +146,31 @@ class RegionMap:
         return None
 
 
-def capture_recv_region(region_map: Optional[RegionMap], pkt: Packet) -> None:
+def choose_reply_scope(
+    request_scope_known: bool,
+    request_was_unscoped_flood: bool,
+    default_scope_known: bool,
+) -> str:
+    """Which transport scope a flooded reply should use.
+
+    Mirrors firmware ``RoutingPolicy.h`` ``chooseReplyScope``:
+    known request region → REQUEST; unscoped flood → NONE (mirror the
+    requester); otherwise DEFAULT if the node has a default region, else NONE.
+    """
+    if request_scope_known:
+        return REPLY_SCOPE_REQUEST
+    if request_was_unscoped_flood:
+        return REPLY_SCOPE_NONE
+    if default_scope_known:
+        return REPLY_SCOPE_DEFAULT
+    return REPLY_SCOPE_NONE
+
+
+def capture_recv_region(
+    region_map: Optional[RegionMap],
+    pkt: Packet,
+    default_key: Optional[bytes] = None,
+) -> None:
     """Record the region a received packet arrived under, onto the packet.
 
     Shared by both RX entrypoints (``Dispatcher._process_received_packet`` and
@@ -142,42 +179,78 @@ def capture_recv_region(region_map: Optional[RegionMap], pkt: Packet) -> None:
 
     - ``TRANSPORT_FLOOD``: match against ``REGION_DENY_FLOOD``-honouring regions
       and record that region's (single) key.
-    - ``FLOOD`` (wildcard) or direct: record None => a reply is sent plain,
-      never the node default.
+    - ``FLOOD``: record whether the wildcard permits it. An allowed wildcard
+      mirrors the request as unscoped; a denied wildcard falls back to DEFAULT.
+    - Direct or unresolved transport scope: fall back to ``default_key``.
 
     A ``None`` region_map (standalone companion) is a no-op: ``_recv_region_captured``
     stays False, so a reply falls through to the dispatcher default.
     """
     if region_map is None:
         return
+    if default_key is None and getattr(pkt, "_recv_region_captured", False):
+        # The host dispatcher may already have captured a valid default before
+        # handing this same Packet to a CompanionBridge. Do not erase that
+        # snapshot merely because the bridge has no duplicate key configured.
+        default_key = getattr(pkt, "_recv_default_scope_key", None)
     pkt._recv_region_captured = True
+    pkt._recv_default_scope_key = default_key
+    pkt._recv_region_unscoped = False
     if pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD:
         entry = region_map.find_match(pkt, mask=REGION_DENY_FLOOD)
-        pkt._recv_region_key = region_map.first_key_for(entry)
+        if entry is not None and entry.is_wildcard():
+            pkt._recv_region_key = None
+            pkt._recv_region_unscoped = True
+        else:
+            pkt._recv_region_key = region_map.first_key_for(entry)
+    elif pkt.get_route_type() == ROUTE_TYPE_FLOOD:
+        pkt._recv_region_key = None
+        pkt._recv_region_unscoped = not (region_map.wildcard.flags & REGION_DENY_FLOOD)
     else:
         pkt._recv_region_key = None
 
 
-def apply_reply_scope(reply_pkt: Packet, request_pkt: Optional[Packet]) -> None:
-    """Scope a freshly-built flood reply to the region its request arrived under.
+def apply_reply_scope(
+    reply_pkt: Packet,
+    request_pkt: Optional[Packet],
+    default_key: Optional[bytes] = None,
+) -> None:
+    """Scope a freshly-built flood reply per firmware ``chooseReplyScope``.
 
-    A repeater/room-server reply carries the request's region (or plain when
-    the request was unscoped/direct), re-hashing the transport code over the
-    reply's own payload — never the request's code, never the node default.
+    Re-hashes the transport code over the reply's own payload — never the
+    request's code.
 
     - Not captured (standalone companion, ``region_map`` None): return without
       marking, so the reply falls through to the dispatcher default.
-    - Captured with a key and the reply is a plain FLOOD: scope it
-      (=> TRANSPORT_FLOOD).
-    - Captured with no key (plain-flood/direct request, or unknown region):
-      leave the reply plain.
+    - Captured + known request region: REQUEST (scope with that key).
+    - Captured + unscoped flood: NONE (plain, marked so a node default cannot
+      override the requester's choice).
+    - Captured + direct / unresolved region: DEFAULT if a default key is
+      available (argument or snapshotted at capture), else NONE (plain).
 
     In every captured case the reply is marked ``_flood_scope_applied`` so the
     dispatcher's node-default scope cannot override this decision.
     """
     if not getattr(request_pkt, "_recv_region_captured", False):
         return
-    key = getattr(request_pkt, "_recv_region_key", None)
-    if key is not None and reply_pkt.get_route_type() == ROUTE_TYPE_FLOOD:
-        scope_packet(reply_pkt, key)
+    req_key = getattr(request_pkt, "_recv_region_key", None)
+    if default_key is None:
+        default_key = getattr(request_pkt, "_recv_default_scope_key", None)
+    scope = choose_reply_scope(
+        req_key is not None,
+        bool(getattr(request_pkt, "_recv_region_unscoped", False)),
+        default_key is not None,
+    )
+    if (
+        scope == REPLY_SCOPE_REQUEST
+        and req_key is not None
+        and reply_pkt.get_route_type() == ROUTE_TYPE_FLOOD
+    ):
+        scope_packet(reply_pkt, req_key)
+    elif (
+        scope == REPLY_SCOPE_DEFAULT
+        and default_key is not None
+        and reply_pkt.get_route_type() == ROUTE_TYPE_FLOOD
+    ):
+        scope_packet(reply_pkt, default_key)
     reply_pkt._flood_scope_applied = True

--- a/src/openhop_core/protocol/region_map.py
+++ b/src/openhop_core/protocol/region_map.py
@@ -228,36 +228,57 @@ def apply_reply_scope(reply_pkt: Packet, request_pkt: Optional[Packet]) -> None:
     Re-hashes the transport code over the reply's own payload -- never copies
     the request's code.
 
-    - Not captured (standalone node, ``region_map`` None): return unmarked, so
-      the reply falls through to the ordinary send precedence.
-    - ``REPLY_SCOPE_REQUEST`` -- captured with a key: scope the reply with it and
-      mark the decision final.
-    - ``REPLY_SCOPE_NONE`` -- the request arrived as an un-scoped flood: mirror
-      that and mark it final, so a node default cannot scope a reply on a path
-      that demonstrably works un-scoped today.
-    - ``REPLY_SCOPE_DEFAULT`` -- the request's scope is unknowable (it arrived
-      DIRECT and so carried no transport codes, or its code matched no Region):
-      return unmarked and let the send layer resolve it.
+    Rows are :func:`choose_reply_scope`'s, which is the literal firmware
+    predicate (``RoutingPolicy.h``); this function decides the two the capture
+    can answer on its own and defers the other two:
 
-    Only the first two decisions set ``_flood_scope_applied``. That mark exists
-    to stop the node default reaching a reply whose scope *this* helper decided,
-    so the deferring case must not set it.
+    1. ``REPLY_SCOPE_REQUEST`` -- captured with a key: scope the reply with it
+       and mark the decision final.
+    2. ``REPLY_SCOPE_NONE``, un-scoped flood: mirror that and mark it final, so
+       a node default cannot scope a reply on a path that demonstrably works
+       un-scoped today.
+    3/4. ``REPLY_SCOPE_DEFAULT``, and the ``REPLY_SCOPE_NONE`` firmware reaches
+       for want of any default: these turn on whether a scope is configured,
+       which is the send layer's to know. Return unmarked and let it answer.
 
-    Why DEFAULT defers instead of scoping here. Firmware splits this case by
-    role: a repeater resolves it as ``sendFloodScoped(default_scope, ...)``
+    Not captured at all (standalone node, ``region_map`` None) also returns
+    unmarked, so the reply falls through to that same precedence.
+
+    Only rows 1 and 2 set ``_flood_scope_applied``. That mark stops the node
+    default reaching a reply whose scope *this* helper decided, so the deferring
+    rows must not set it.
+
+    Why rows 3 and 4 defer. Firmware splits them by role. A repeater resolves
+    DEFAULT as ``sendFloodScoped(default_scope, ...)``
     (``simple_repeater/MyMesh.cpp``), while a companion answers the same case
     with ``sendFloodScoped(recipient, ...)``, which is ``send_unscoped`` first,
     then ``send_scope``, else ``default_scope``
     (``companion_radio/MyMesh.cpp``). One helper here serves both roles, and
     ``Dispatcher._apply_flood_scope`` / ``CompanionBase._apply_flood_scope``
-    already implement exactly that precedence -- including firmware's final
-    ``REPLY_SCOPE_NONE``, since a node with no scope configured at all leaves the
-    packet a plain flood. Deciding here would duplicate that chain and, by
-    marking the packet, suppress it: an operator's explicit-unscoped flag and
-    transient override would both be silently overridden. It would also bind the
-    reply to the default as it stood at RX rather than at TX.
+    already implement that precedence -- including firmware's final NONE, since
+    a node with nothing configured leaves the packet a plain flood. Deciding
+    here would duplicate the chain and, by marking the packet, suppress it: an
+    operator's explicit-unscoped flag and transient override would both be
+    silently overridden. It would also bind the reply to the default as it
+    stood at RX rather than at TX.
 
-    Replying un-scoped in this case is the bug MeshCore PR #3106 fixed: a
+    Caller contract: the reply must reach the radio through one of those two
+    resolvers. Every send path in this tree does -- a handler reply travels
+    ``Dispatcher.send_packet``, and a ``CompanionBridge`` reply travels the
+    host's packet injector, which for the repeater ends at the same call. An
+    application that serializes a deferred reply straight to a radio would put
+    it on air plain.
+
+    Known divergence, deliberate: rows 3 and 4 reach a precedence that also
+    honours the transient override and the explicit-unscoped flag, because the
+    companion role requires it. Firmware's *repeater* has neither concept, so a
+    node holding a RegionMap and an override but no default would send the
+    reply scoped where firmware's repeater sends it plain. No topology here
+    reaches that state -- ``CompanionBridge`` never writes those dispatcher
+    fields, and a ``CompanionRadio`` owns its own dispatcher, where honouring
+    them is the correct companion behaviour.
+
+    Replying un-scoped in rows 3/4 is the bug MeshCore PR #3106 fixed: a
     repeater on the way back running ``flood.max.unscoped=0`` drops such a reply
     at hop 0. The fix is that a configured default now reaches it -- which it
     does through the send layer.
@@ -265,22 +286,14 @@ def apply_reply_scope(reply_pkt: Packet, request_pkt: Optional[Packet]) -> None:
     if not getattr(request_pkt, "_recv_region_captured", False):
         return
     req_key = getattr(request_pkt, "_recv_region_key", None)
-    scope = choose_reply_scope(
-        req_key is not None,
-        bool(getattr(request_pkt, "_recv_region_unscoped", False)),
-        # This third input is the send layer's to answer, and it resolves
-        # DEFAULT and the no-default NONE identically, from the configuration
-        # current at TX. Passing True asks for that deferred outcome; it is not
-        # a claim that a default is configured.
-        default_scope_known=True,
-    )
-    if scope == REPLY_SCOPE_REQUEST:
+    if req_key is not None:
+        # Row 1: REPLY_SCOPE_REQUEST.
         if reply_pkt.get_route_type() == ROUTE_TYPE_FLOOD:
             scope_packet(reply_pkt, req_key)
         reply_pkt._flood_scope_applied = True
         return
-    if scope == REPLY_SCOPE_NONE:
-        # Un-scoped flood request: leave the reply plain, decision final.
+    if getattr(request_pkt, "_recv_region_unscoped", False):
+        # Row 2: REPLY_SCOPE_NONE, mirroring the requester's un-scoped choice.
         reply_pkt._flood_scope_applied = True
         return
-    # REPLY_SCOPE_DEFAULT: leave unmarked for the send layer.
+    # Rows 3 and 4: left unmarked for the send layer.

--- a/tests/test_companion_bridge.py
+++ b/tests/test_companion_bridge.py
@@ -15,6 +15,7 @@ from openhop_core.protocol import CryptoUtils, Identity, LocalIdentity, Packet, 
 from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
+    PAYLOAD_TYPE_ANON_REQ,
     PAYLOAD_TYPE_PATH,
     PAYLOAD_TYPE_RAW_CUSTOM,
     PAYLOAD_TYPE_RESPONSE,
@@ -83,6 +84,28 @@ class TestCompanionBridgeInit:
             authenticate_callback=auth_cb,
         )
         assert bridge._handlers is not None
+
+    def test_login_handler_reads_and_clears_contact_out_path(self):
+        """Production bridge wiring exposes its contact route to login replies."""
+        bridge = CompanionBridge(LocalIdentity(), MockPacketInjector())
+        peer = LocalIdentity()
+        path_len = PathUtils.encode_path_len(1, 2)
+        contact = Contact(
+            public_key=peer.get_public_key(),
+            out_path_len=path_len,
+            out_path=b"\x11\x22",
+        )
+        assert bridge.contacts.add(contact) is True
+
+        handler = bridge._handlers[PAYLOAD_TYPE_ANON_REQ]
+        peer_identity = Identity(peer.get_public_key())
+        assert handler.get_out_path(peer_identity) == (b"\x11\x22", path_len)
+
+        handler.clear_out_path(peer_identity)
+        updated = bridge.contacts.get_by_key(peer.get_public_key())
+        assert updated is not None
+        assert updated.out_path_len == -1
+        assert updated.out_path == b""
 
     def test_set_other_params_propagates_multi_acks(self):
         """set_other_params pushes the multi_acks pref into the text handler."""
@@ -499,22 +522,23 @@ class TestCompanionBridgeSendAndShare:
         raw_bytes = source.write_to()
         result = await bridge.send_raw_packet(0, raw_bytes)
         await bridge.stop()
-        assert result is True
+        assert result.success is True
         assert len(injector.calls) == 1
         pkt, wait_for_ack = injector.calls[0]
         # The injected packet round-trips the original wire bytes.
         assert pkt.write_to() == raw_bytes
         assert wait_for_ack is False
 
-    async def test_send_raw_packet_unparseable_returns_false(self):
-        """send_raw_packet returns False (no injection) when bytes don't parse."""
+    async def test_send_raw_packet_unparseable_returns_illegal_arg(self):
+        """Parse failure is illegal_arg (not send_failed / table-full)."""
         injector = MockPacketInjector()
         bridge = CompanionBridge(LocalIdentity(), injector)
         await bridge.start()
         # Header byte only: read_from has no path_len/payload to parse -> failure.
         result = await bridge.send_raw_packet(0, b"\x00")
         await bridge.stop()
-        assert result is False
+        assert result.success is False
+        assert result.error == "illegal_arg"
         assert injector.calls == []
 
 

--- a/tests/test_flood_scope_fix.py
+++ b/tests/test_flood_scope_fix.py
@@ -88,6 +88,22 @@ def _make_companion(node_name: str = "test") -> CompanionRadio:
     return CompanionRadio(radio=MockRadio(), identity=LocalIdentity(), node_name=node_name)
 
 
+def _resolve_at_tx(reply: Packet, *, default_key=None, override=None, unscoped=False) -> Packet:
+    """Run a built reply through the send layer, as an actual TX would.
+
+    ``apply_reply_scope`` defers REPLY_SCOPE_DEFAULT, so a test that wants to
+    see the resulting scope has to ask the layer that decides it. Mirrors
+    firmware's ``sendFloodScoped(recipient, ...)``: explicit-unscoped first,
+    then the transient override, else the persisted default.
+    """
+    dispatcher = Dispatcher(MockRadio())
+    dispatcher.default_flood_transport_key = default_key
+    dispatcher.flood_transport_key = override
+    dispatcher.flood_unscoped = unscoped
+    dispatcher._apply_flood_scope(reply)
+    return reply
+
+
 def _make_flood_packet() -> Packet:
     """A minimal flood-routed advert packet (for dispatcher-level unit tests)."""
     return PacketBuilder.create_advert(local_identity=LocalIdentity(), name="x", route_type="flood")
@@ -454,7 +470,8 @@ class TestRepeaterReplyCarriesRegion:
 
     @pytest.mark.asyncio
     async def test_unknown_region_reply_stays_plain(self):
-        """(10) Unresolved region and no default => plain reply (REPLY_SCOPE_NONE)."""
+        """(10) Unresolved region: deferred, and with nothing configured the
+        send layer leaves it plain -- firmware's final REPLY_SCOPE_NONE."""
         region_map, _a_key, _b_key = self._region_map()
         server, client = LocalIdentity(), LocalIdentity()
         handler, sent = _login_handler(server)
@@ -467,13 +484,15 @@ class TestRepeaterReplyCarriesRegion:
 
         await handler(req)
         reply = sent[0]
+        assert reply._flood_scope_applied is False
+        _resolve_at_tx(reply)
         assert reply.get_route_type() == ROUTE_TYPE_FLOOD
         assert reply.transport_codes == [0, 0]
-        assert reply._flood_scope_applied is True
 
     @pytest.mark.asyncio
     async def test_unknown_region_uses_default_scope(self):
-        """Unresolved TRANSPORT_FLOOD + default region → REPLY_SCOPE_DEFAULT."""
+        """Unresolved TRANSPORT_FLOOD + default region → REPLY_SCOPE_DEFAULT,
+        resolved by the send layer rather than pinned here."""
         region_map, _a_key, _b_key = self._region_map()
         default_key = get_auto_key_for("#default-region")
         server, client = LocalIdentity(), LocalIdentity()
@@ -481,32 +500,35 @@ class TestRepeaterReplyCarriesRegion:
 
         unknown_key = get_auto_key_for("#not-in-map")
         req = _build_login_req(server, client, region_key=unknown_key)
-        capture_recv_region(region_map, req, default_key=default_key)
+        capture_recv_region(region_map, req)
 
         await handler(req)
         reply = sent[0]
+        assert reply._flood_scope_applied is False
+        _resolve_at_tx(reply, default_key=default_key)
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
-        assert reply._flood_scope_applied is True
 
     @pytest.mark.asyncio
     async def test_direct_login_flood_fallback_uses_default_scope(self):
-        """Direct login with no out_path + default → flood RESPONSE scoped DEFAULT."""
+        """Direct login with no out_path + default → flood RESPONSE, deferred,
+        then scoped DEFAULT by the send layer."""
         region_map, _a_key, _b_key = self._region_map()
         default_key = get_auto_key_for("#default-region")
         server, client = LocalIdentity(), LocalIdentity()
         handler, sent = _login_handler(server)
 
         req = _build_login_req(server, client, route_type=ROUTE_TYPE_DIRECT)
-        capture_recv_region(region_map, req, default_key=default_key)
+        capture_recv_region(region_map, req)
 
         await handler(req)
         reply = sent[0]
         assert reply.get_payload_type() == PAYLOAD_TYPE_RESPONSE
         assert reply.is_route_flood()
+        assert reply._flood_scope_applied is False
+        _resolve_at_tx(reply, default_key=default_key)
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
-        assert reply._flood_scope_applied is True
 
     @pytest.mark.asyncio
     async def test_plain_flood_stays_plain_even_with_default(self):
@@ -517,17 +539,21 @@ class TestRepeaterReplyCarriesRegion:
         handler, sent = _login_handler(server)
 
         req = _build_login_req(server, client, region_key=None)
-        capture_recv_region(region_map, req, default_key=default_key)
+        capture_recv_region(region_map, req)
 
         await handler(req)
         reply = sent[0]
+        # An un-scoped request is a decision, so it is marked final and the
+        # node default cannot reach it.
+        assert reply._flood_scope_applied is True
+        _resolve_at_tx(reply, default_key=default_key)
         assert reply.get_route_type() == ROUTE_TYPE_FLOOD
         assert reply.transport_codes == [0, 0]
-        assert reply._flood_scope_applied is True
 
     @pytest.mark.asyncio
     async def test_plain_flood_uses_default_when_wildcard_denies_flood(self):
-        """A denied wildcard makes request scope unknown, so DEFAULT wins."""
+        """A denied wildcard makes request scope unknown, so the reply defers
+        and the send layer supplies DEFAULT."""
         region_map, _a_key, _b_key = self._region_map()
         region_map.wildcard.flags |= REGION_DENY_FLOOD
         default_key = get_auto_key_for("#default-region")
@@ -535,13 +561,14 @@ class TestRepeaterReplyCarriesRegion:
         handler, sent = _login_handler(server)
 
         req = _build_login_req(server, client, region_key=None)
-        capture_recv_region(region_map, req, default_key=default_key)
+        capture_recv_region(region_map, req)
 
         await handler(req)
         reply = sent[0]
+        assert reply._flood_scope_applied is False
+        _resolve_at_tx(reply, default_key=default_key)
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
-        assert reply._flood_scope_applied is True
 
     @pytest.mark.asyncio
     async def test_interleaved_requests_each_reply_scoped_correctly(self):
@@ -642,7 +669,8 @@ class TestRepeaterReqReplyScope:
 
     @pytest.mark.asyncio
     async def test_direct_req_without_out_path_or_default_replies_plain_flood(self):
-        """DIRECT + no out_path + no default → REPLY_SCOPE_NONE (plain, marked)."""
+        """DIRECT + no out_path: deferred, and with nothing configured the send
+        layer leaves it plain -- firmware's final REPLY_SCOPE_NONE."""
         region_map = RegionMap([RegionEntry(id=1, name="#region-a")])
         server, client = LocalIdentity(), LocalIdentity()
         handler = self._req_handler(server, self._client_info(client))  # no out_path
@@ -657,12 +685,9 @@ class TestRepeaterReqReplyScope:
         reply = result.response
         assert reply is not None
         assert reply.get_route_type() == ROUTE_TYPE_FLOOD
-        assert reply._flood_scope_applied is True
+        assert reply._flood_scope_applied is False
 
-        # Marked applied: a later dispatcher default cannot override NONE.
-        dispatcher = Dispatcher(MockRadio())
-        dispatcher.default_flood_transport_key = get_auto_key_for("#region-a")
-        dispatcher._apply_flood_scope(reply)
+        _resolve_at_tx(reply)
         assert reply.get_route_type() == ROUTE_TYPE_FLOOD
         assert reply.transport_codes == [0, 0]
 
@@ -671,7 +696,9 @@ class TestRepeaterReqReplyScope:
         """DIRECT + no out_path + default region → REPLY_SCOPE_DEFAULT.
 
         Firmware chooseReplyScope(false, false, true). Unscoped would be
-        dropped at hop 0 when flood.max.unscoped=0.
+        dropped at hop 0 when flood.max.unscoped=0. The key arrives from the
+        send layer, which is where firmware's repeater gets it too
+        (sendFloodScoped(default_scope, ...)).
         """
         default_key = get_auto_key_for("#region-a")
         region_map = RegionMap([RegionEntry(id=1, name="#region-a")])
@@ -679,18 +706,14 @@ class TestRepeaterReqReplyScope:
         handler = self._req_handler(server, self._client_info(client))
 
         req = self._build_req(server, client, route_type=ROUTE_TYPE_DIRECT)
-        capture_recv_region(region_map, req, default_key=default_key)
+        capture_recv_region(region_map, req)
 
         result = await handler(req)
         reply = result.response
         assert reply is not None
+        assert reply._flood_scope_applied is False
+        _resolve_at_tx(reply, default_key=default_key)
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
-        assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
-        assert reply._flood_scope_applied is True
-
-        dispatcher = Dispatcher(MockRadio())
-        dispatcher.default_flood_transport_key = get_auto_key_for("#other")
-        dispatcher._apply_flood_scope(reply)
         assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
 
     @pytest.mark.asyncio
@@ -797,7 +820,7 @@ class TestRegionCaptureBothEntrypoints:
         assert len(seen) == 1
         assert seen[0]._recv_region_captured is True
         assert seen[0]._recv_region_key == b_key
-        assert seen[0]._recv_default_scope_key == get_auto_key_for("#default-region")
+        assert seen[0]._recv_region_unscoped is False
 
     @pytest.mark.asyncio
     async def test_capture_via_bridge_entrypoint(self):

--- a/tests/test_flood_scope_fix.py
+++ b/tests/test_flood_scope_fix.py
@@ -825,8 +825,13 @@ class TestFinalDecisionsSurviveBothResolvers:
         assert reply.transport_codes == [0, 0]
 
     def test_companion_resolver_still_scopes_its_own_fresh_packets(self):
-        """The guard must not disarm the companion's ordinary scoping: every
-        call site builds its packet immediately before resolving it."""
+        """The guard must not disarm the companion's ordinary scoping.
+
+        Pins the mechanism -- an unmarked packet still scopes. That this is
+        what every production call site hands it (each builds its packet
+        immediately before resolving it, so none is ever pre-marked) is a
+        property of those call sites, not something this test establishes.
+        """
         companion = _make_companion()
         key = get_auto_key_for("#override-region")
         companion.set_flood_scope(key)

--- a/tests/test_flood_scope_fix.py
+++ b/tests/test_flood_scope_fix.py
@@ -39,6 +39,7 @@ from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_ANON_REQ,
     PAYLOAD_TYPE_PATH,
     PAYLOAD_TYPE_REQ,
+    PAYLOAD_TYPE_RESPONSE,
     PAYLOAD_TYPE_TXT_MSG,
     ROUTE_TYPE_DIRECT,
     ROUTE_TYPE_FLOOD,
@@ -46,6 +47,7 @@ from openhop_core.protocol.constants import (
     TXT_TYPE_PLAIN,
 )
 from openhop_core.protocol.region_map import (
+    REGION_DENY_FLOOD,
     RegionEntry,
     RegionMap,
     capture_recv_region,
@@ -452,7 +454,7 @@ class TestRepeaterReplyCarriesRegion:
 
     @pytest.mark.asyncio
     async def test_unknown_region_reply_stays_plain(self):
-        """(10) A request scoped to a region absent from the map => plain reply."""
+        """(10) Unresolved region and no default => plain reply (REPLY_SCOPE_NONE)."""
         region_map, _a_key, _b_key = self._region_map()
         server, client = LocalIdentity(), LocalIdentity()
         handler, sent = _login_handler(server)
@@ -467,6 +469,78 @@ class TestRepeaterReplyCarriesRegion:
         reply = sent[0]
         assert reply.get_route_type() == ROUTE_TYPE_FLOOD
         assert reply.transport_codes == [0, 0]
+        assert reply._flood_scope_applied is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_region_uses_default_scope(self):
+        """Unresolved TRANSPORT_FLOOD + default region → REPLY_SCOPE_DEFAULT."""
+        region_map, _a_key, _b_key = self._region_map()
+        default_key = get_auto_key_for("#default-region")
+        server, client = LocalIdentity(), LocalIdentity()
+        handler, sent = _login_handler(server)
+
+        unknown_key = get_auto_key_for("#not-in-map")
+        req = _build_login_req(server, client, region_key=unknown_key)
+        capture_recv_region(region_map, req, default_key=default_key)
+
+        await handler(req)
+        reply = sent[0]
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
+        assert reply._flood_scope_applied is True
+
+    @pytest.mark.asyncio
+    async def test_direct_login_flood_fallback_uses_default_scope(self):
+        """Direct login with no out_path + default → flood RESPONSE scoped DEFAULT."""
+        region_map, _a_key, _b_key = self._region_map()
+        default_key = get_auto_key_for("#default-region")
+        server, client = LocalIdentity(), LocalIdentity()
+        handler, sent = _login_handler(server)
+
+        req = _build_login_req(server, client, route_type=ROUTE_TYPE_DIRECT)
+        capture_recv_region(region_map, req, default_key=default_key)
+
+        await handler(req)
+        reply = sent[0]
+        assert reply.get_payload_type() == PAYLOAD_TYPE_RESPONSE
+        assert reply.is_route_flood()
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
+        assert reply._flood_scope_applied is True
+
+    @pytest.mark.asyncio
+    async def test_plain_flood_stays_plain_even_with_default(self):
+        """Unscoped flood mirrors NONE even when a default region exists."""
+        region_map, _a_key, _b_key = self._region_map()
+        default_key = get_auto_key_for("#default-region")
+        server, client = LocalIdentity(), LocalIdentity()
+        handler, sent = _login_handler(server)
+
+        req = _build_login_req(server, client, region_key=None)
+        capture_recv_region(region_map, req, default_key=default_key)
+
+        await handler(req)
+        reply = sent[0]
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+        assert reply.transport_codes == [0, 0]
+        assert reply._flood_scope_applied is True
+
+    @pytest.mark.asyncio
+    async def test_plain_flood_uses_default_when_wildcard_denies_flood(self):
+        """A denied wildcard makes request scope unknown, so DEFAULT wins."""
+        region_map, _a_key, _b_key = self._region_map()
+        region_map.wildcard.flags |= REGION_DENY_FLOOD
+        default_key = get_auto_key_for("#default-region")
+        server, client = LocalIdentity(), LocalIdentity()
+        handler, sent = _login_handler(server)
+
+        req = _build_login_req(server, client, region_key=None)
+        capture_recv_region(region_map, req, default_key=default_key)
+
+        await handler(req)
+        reply = sent[0]
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
         assert reply._flood_scope_applied is True
 
     @pytest.mark.asyncio
@@ -513,12 +587,11 @@ class TestRepeaterReqReplyScope:
           else                                          sendFloodReply(reply, ...);  // (b)
         }
 
-    ``sendFloodReply`` scopes to ``recv_pkt_region`` — which is NULL for a DIRECT
-    request — so branch (b) is a plain, unscoped flood. Branch (b) used to be the
-    one reply builder that never marked its decision, so the dispatcher's node
-    default/override stamped a region onto it that firmware would never use. It
-    is the reply that carries a status/telemetry/neighbours response whenever the
-    ACL holds no out_path for the client.
+    ``sendFloodReply`` uses ``chooseReplyScope``: a DIRECT request has
+    ``recv_pkt_region`` NULL, so the flood RESPONSE is DEFAULT-scoped when
+    the node has a default region, else plain. On a node with no RegionMap
+    the mark is not applied and the reply falls through to the dispatcher
+    default (BaseChatMesh ``sendFloodScoped``).
     """
 
     def _req_handler(self, server: LocalIdentity, client_info):
@@ -568,12 +641,8 @@ class TestRepeaterReqReplyScope:
         return pkt
 
     @pytest.mark.asyncio
-    async def test_direct_req_without_out_path_replies_plain_flood(self):
-        """Branch (b): the node default must not reach this reply.
-
-        A DIRECT request captures no region (firmware ``recv_pkt_region`` is
-        NULL), so the flood RESPONSE stays plain and is marked applied.
-        """
+    async def test_direct_req_without_out_path_or_default_replies_plain_flood(self):
+        """DIRECT + no out_path + no default → REPLY_SCOPE_NONE (plain, marked)."""
         region_map = RegionMap([RegionEntry(id=1, name="#region-a")])
         server, client = LocalIdentity(), LocalIdentity()
         handler = self._req_handler(server, self._client_info(client))  # no out_path
@@ -590,12 +659,39 @@ class TestRepeaterReqReplyScope:
         assert reply.get_route_type() == ROUTE_TYPE_FLOOD
         assert reply._flood_scope_applied is True
 
-        # The gate has to actually hold at TX time against a configured default.
+        # Marked applied: a later dispatcher default cannot override NONE.
         dispatcher = Dispatcher(MockRadio())
         dispatcher.default_flood_transport_key = get_auto_key_for("#region-a")
         dispatcher._apply_flood_scope(reply)
         assert reply.get_route_type() == ROUTE_TYPE_FLOOD
         assert reply.transport_codes == [0, 0]
+
+    @pytest.mark.asyncio
+    async def test_direct_req_without_out_path_uses_default_scope(self):
+        """DIRECT + no out_path + default region → REPLY_SCOPE_DEFAULT.
+
+        Firmware chooseReplyScope(false, false, true). Unscoped would be
+        dropped at hop 0 when flood.max.unscoped=0.
+        """
+        default_key = get_auto_key_for("#region-a")
+        region_map = RegionMap([RegionEntry(id=1, name="#region-a")])
+        server, client = LocalIdentity(), LocalIdentity()
+        handler = self._req_handler(server, self._client_info(client))
+
+        req = self._build_req(server, client, route_type=ROUTE_TYPE_DIRECT)
+        capture_recv_region(region_map, req, default_key=default_key)
+
+        result = await handler(req)
+        reply = result.response
+        assert reply is not None
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
+        assert reply._flood_scope_applied is True
+
+        dispatcher = Dispatcher(MockRadio())
+        dispatcher.default_flood_transport_key = get_auto_key_for("#other")
+        dispatcher._apply_flood_scope(reply)
+        assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
 
     @pytest.mark.asyncio
     async def test_flood_req_path_return_carries_request_region(self):
@@ -686,6 +782,7 @@ class TestRegionCaptureBothEntrypoints:
         region_map, b_key = self._region_map()
         dispatcher = Dispatcher(MockRadio())
         dispatcher.region_map = region_map
+        dispatcher.default_flood_transport_key = get_auto_key_for("#default-region")
 
         seen: list[Packet] = []
 
@@ -700,6 +797,7 @@ class TestRegionCaptureBothEntrypoints:
         assert len(seen) == 1
         assert seen[0]._recv_region_captured is True
         assert seen[0]._recv_region_key == b_key
+        assert seen[0]._recv_default_scope_key == get_auto_key_for("#default-region")
 
     @pytest.mark.asyncio
     async def test_capture_via_bridge_entrypoint(self):

--- a/tests/test_flood_scope_fix.py
+++ b/tests/test_flood_scope_fix.py
@@ -50,6 +50,7 @@ from openhop_core.protocol.region_map import (
     REGION_DENY_FLOOD,
     RegionEntry,
     RegionMap,
+    apply_reply_scope,
     capture_recv_region,
 )
 from openhop_core.protocol.transport_keys import (
@@ -782,6 +783,60 @@ class TestRepeaterReqReplyScope:
         dispatcher._apply_flood_scope(reply)
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
+
+
+class TestFinalDecisionsSurviveBothResolvers:
+    """``_flood_scope_applied`` must outrank *both* send-layer resolvers.
+
+    The mark exists so a scope the reply helper decided is never re-decided.
+    ``Dispatcher._apply_flood_scope`` has always checked it first;
+    ``CompanionBase._apply_flood_scope`` set it without ever checking it, so a
+    reply deliberately left plain could still be scoped on the way out.
+    """
+
+    @staticmethod
+    def _unscoped_flood_reply():
+        """A reply to an un-scoped flood: chooseReplyScope NONE, marked final."""
+        req = _make_flood_packet()
+        capture_recv_region(RegionMap(), req)
+        assert req._recv_region_unscoped is True
+        reply = _make_flood_packet()
+        apply_reply_scope(reply, req)
+        assert reply._flood_scope_applied is True
+        return reply
+
+    def test_dispatcher_resolver_leaves_a_final_plain_reply_alone(self):
+        reply = self._unscoped_flood_reply()
+        _resolve_at_tx(reply, default_key=get_auto_key_for("#default-region"))
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+        assert reply.transport_codes == [0, 0]
+
+    def test_companion_resolver_leaves_a_final_plain_reply_alone(self):
+        """Firmware gives the requester's un-scoped choice precedence
+        (chooseReplyScope(false, true, ...) -> NONE, then a plain sendFlood),
+        so a configured companion scope must not reach this reply either."""
+        companion = _make_companion()
+        companion.set_flood_scope(get_auto_key_for("#override-region"))
+
+        reply = self._unscoped_flood_reply()
+        companion._apply_flood_scope(reply)
+
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+        assert reply.transport_codes == [0, 0]
+
+    def test_companion_resolver_still_scopes_its_own_fresh_packets(self):
+        """The guard must not disarm the companion's ordinary scoping: every
+        call site builds its packet immediately before resolving it."""
+        companion = _make_companion()
+        key = get_auto_key_for("#override-region")
+        companion.set_flood_scope(key)
+
+        pkt = _make_flood_packet()
+        assert pkt._flood_scope_applied is False
+        companion._apply_flood_scope(pkt)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt.transport_codes[0] == calc_transport_code(key, pkt)
 
 
 class TestRegionCaptureBothEntrypoints:

--- a/tests/test_flood_scope_fix.py
+++ b/tests/test_flood_scope_fix.py
@@ -17,6 +17,7 @@ import asyncio
 import contextlib
 import struct
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -1056,3 +1057,83 @@ class TestRegionCaptureBothEntrypoints:
 
         assert pkt._recv_region_captured is False
         assert pkt._recv_region_key is None
+
+
+class TestBuilderFreshnessIsEnforced:
+    """A request builder that reuses a packet is caught, not silently obeyed.
+
+    Both send-layer resolvers skip a packet already carrying a decision, which
+    is what lets a decided reply keep its region. The side effect is that a
+    *reused* packet is indistinguishable from a decided one: the second caller
+    of a caching builder would get a packet the first attempt already marked,
+    and its send would skip scoping and go out plain. Since the failure is
+    invisible downstream, ``_take_built_packet`` rejects it at the builder.
+
+    Every builder in the tree constructs through ``PacketBuilder``, so this
+    guards against a future edit rather than anything reachable today.
+    """
+
+    @staticmethod
+    def _fresh_builder():
+        return lambda: (_make_flood_packet(), 7)
+
+    def test_a_fresh_builder_passes_through_with_its_tag(self):
+        companion = _make_companion()
+        pkt, tag = companion._take_built_packet(self._fresh_builder())
+        assert pkt._flood_scope_applied is False
+        assert tag == 7
+
+    def test_a_builder_reusing_a_scoped_packet_is_rejected(self):
+        """The live hazard: attempt 1 marks it, so the retry would skip scoping."""
+        companion = _make_companion()
+        cached = _make_flood_packet()
+        companion._apply_flood_scope(cached)  # what attempt 1 does
+        assert cached._flood_scope_applied is True
+
+        with pytest.raises(ValueError, match="already carries send-time"):
+            companion._take_built_packet(lambda: (cached, None))
+
+    def test_a_builder_reusing_a_path_hash_marked_packet_is_rejected(self):
+        """``_path_hash_mode_applied`` suppresses the dispatcher the same way.
+
+        Every send site pairs ``_apply_flood_scope`` with
+        ``_apply_path_hash_mode``, and ``Packet.read_from`` clears both together,
+        so a packet carrying either mark is equally stale.
+        """
+        companion = _make_companion()
+        cached = _make_flood_packet()
+        cached.apply_path_hash_mode(0, mark_applied=True)
+        assert cached._path_hash_mode_applied is True
+        assert cached._flood_scope_applied is False, "isolates this mark from the other"
+
+        with pytest.raises(ValueError, match="already carries send-time"):
+            companion._take_built_packet(lambda: (cached, None))
+
+    def test_the_retry_path_is_where_the_guard_sits(self):
+        """``_build_retry_packet`` is the chokepoint every retry flows through.
+
+        Its docstring promises the packet comes back un-scoped for the caller to
+        resolve; this holds it to that. A caching builder trips it even on the
+        forced-flood branch, where ``out_path_len`` is masked before the call.
+        """
+        companion = _make_companion()
+        proxy = SimpleNamespace(out_path_len=1)
+
+        cached = _make_flood_packet()
+        companion._apply_flood_scope(cached)
+        with pytest.raises(ValueError, match="already carries send-time"):
+            companion._build_retry_packet(lambda: (cached, None), proxy, "retry")
+
+        # The mask is restored even though the builder's contract was broken.
+        assert proxy.out_path_len == 1
+
+    def test_a_per_call_builder_still_retries_normally(self):
+        """The guard must not disarm the ordinary retry path."""
+        companion = _make_companion()
+        proxy = SimpleNamespace(out_path_len=1)
+
+        pkt, tag = companion._build_retry_packet(self._fresh_builder(), proxy, "retry")
+
+        assert pkt._flood_scope_applied is False, "retry must reach the caller un-scoped"
+        assert tag == 7
+        assert proxy.out_path_len == 1

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -8,6 +8,7 @@ import sys
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from openhop_core.companion.constants import (
     CMD_GET_CUSTOM_VARS,
     CMD_GET_DEVICE_TIME,
@@ -455,13 +456,11 @@ async def test_cmd_add_update_contact_preserves_exact_encoded_path_bytes(encoded
 
 
 @pytest.mark.asyncio
-async def test_cmd_send_raw_data_short_of_min_payload_writes_unsupported():
-    """path_len=0 but fewer than 4 payload bytes -> ERR_CODE_UNSUPPORTED_CMD.
+async def test_cmd_send_raw_data_never_enters_branch_writes_unsupported():
+    """Firmware `len < 6` (command byte included) never enters CMD_SEND_RAW_DATA.
 
-    Previously this was rejected by a blanket `len(data) < 6` guard; now it
-    falls through to the path-aware bounds check (1 + path_byte_len + 4 >
-    len(data)), which rejects it for the same reason firmware does
-    (MyMesh.cpp: `i + path_len + 4 <= len` fails) with the same error code.
+    ``data`` is command-stripped, so fewer than 5 bytes is that case and must
+    stay ``ERR_CODE_UNSUPPORTED_CMD`` (MyMesh.cpp catch-all).
     """
     bridge = _MockBridgeSendRawDirect()
     server = CompanionFrameServer(bridge, "hash", port=0)
@@ -470,6 +469,25 @@ async def test_cmd_send_raw_data_short_of_min_payload_writes_unsupported():
     await server._cmd_send_raw_data(b"\x00\x00\x00")
     assert len(bridge.calls) == 0
     server._write_err.assert_called_once_with(ERR_CODE_UNSUPPORTED_CMD)
+    server._write_ok.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_raw_data_short_of_min_payload_writes_illegal_arg():
+    """Valid path, entered the branch, remaining payload < 4 → ILLEGAL_ARG.
+
+    Firmware: ``len >= 6`` enters; ``isValidPathLen``; ``writePath``; then
+    ``i + 4 > len`` → ``ERR_CODE_ILLEGAL_ARG`` (dev / 0cce9197). Five
+    command-stripped bytes is firmware ``len == 6``. path_len=1 consumes one
+    hop byte, leaving 3 payload bytes.
+    """
+    bridge = _MockBridgeSendRawDirect()
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_ok = Mock()
+    server._write_err = Mock()
+    await server._cmd_send_raw_data(bytes([1, 0x42, 0x01, 0x02, 0x03]))
+    assert len(bridge.calls) == 0
+    server._write_err.assert_called_once_with(ERR_CODE_ILLEGAL_ARG)
     server._write_ok.assert_not_called()
 
 
@@ -570,7 +588,11 @@ async def test_cmd_send_raw_data_invalid_path_encoding():
 
 @pytest.mark.asyncio
 async def test_cmd_send_raw_data_truncated_multibyte_path():
-    """CMD_SEND_RAW_DATA with not enough path bytes for 2-byte encoding → error."""
+    """Valid encoding, not enough path+payload bytes → ILLEGAL_ARG.
+
+    Firmware ``writePath`` still advances by the encoded byte length, then
+    ``i + 4 > len`` fails with ``ERR_CODE_ILLEGAL_ARG``.
+    """
     from openhop_core.protocol.packet_utils import PathUtils
 
     bridge = _MockBridgeSendRawDirect()
@@ -583,7 +605,7 @@ async def test_cmd_send_raw_data_truncated_multibyte_path():
     data = bytes([path_len_byte]) + b"\x00" * 8  # only 8 bytes, need 6+4=10
     await server._cmd_send_raw_data(data)
     assert len(bridge.calls) == 0
-    server._write_err.assert_called_once_with(ERR_CODE_UNSUPPORTED_CMD)
+    server._write_err.assert_called_once_with(ERR_CODE_ILLEGAL_ARG)
 
 
 @pytest.mark.asyncio
@@ -1506,6 +1528,32 @@ async def test_cmd_send_raw_packet_too_short():
     server._write_err = Mock()
     await server._cmd_send_raw_packet(bytes([0x00]))
     server._write_err.assert_called_once_with(ERR_CODE_ILLEGAL_ARG)
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_raw_packet_parse_fail_writes_illegal_arg():
+    """Unparseable body maps to ILLEGAL_ARG (firmware releasePacket + ILLEGAL_ARG)."""
+    bridge = Mock()
+    bridge.send_raw_packet = AsyncMock(return_value=SentResult(success=False, error="illegal_arg"))
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_ok = Mock()
+    server._write_err = Mock()
+    await server._cmd_send_raw_packet(bytes([0x00, 0xAA, 0xBB]))
+    server._write_err.assert_called_once_with(ERR_CODE_ILLEGAL_ARG)
+    server._write_ok.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_raw_packet_send_failure_writes_table_full():
+    """TX/queue full still maps to TABLE_FULL."""
+    bridge = Mock()
+    bridge.send_raw_packet = AsyncMock(return_value=SentResult(success=False, error="send_failed"))
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_ok = Mock()
+    server._write_err = Mock()
+    await server._cmd_send_raw_packet(bytes([0x00, 0xAA, 0xBB]))
+    server._write_err.assert_called_once_with(ERR_CODE_TABLE_FULL)
+    server._write_ok.assert_not_called()
 
 
 def test_parse_binary_response_regions():

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -2261,6 +2261,103 @@ class TestLoginServerHandler:
         assert cleared[0] == self.client_identity_local.get_public_key()
         assert self.sent_packets[0][0].get_payload_type() == PAYLOAD_TYPE_PATH
 
+    # ------------------------------------------------------------------
+    # ACL callback guards.
+    #
+    # ``get_out_path`` / ``clear_out_path`` are supplied by the application, so
+    # unlike firmware's fixed ClientInfo they can return any shape or raise.
+    # A bad ACL entry may cost the direct route or the path clear; it must
+    # never cost the login reply, which is the invariant the flood fallback
+    # exists to state. Each of these fails if its guard is removed.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_a_raising_get_out_path_never_costs_the_reply(self):
+        """An ACL that raises falls back to flooding, as if it had no path."""
+
+        def _boom(_ident):
+            raise RuntimeError("ACL exploded")
+
+        self.handler.get_out_path = _boom
+
+        await self.handler(self._build_login_packet(route_type="direct"))
+
+        assert len(self.sent_packets) == 1
+        response_pkt, _ = self.sent_packets[0]
+        assert response_pkt.get_payload_type() == PAYLOAD_TYPE_RESPONSE
+        assert response_pkt.is_route_flood()
+        response_pkt.write_to()
+
+    @pytest.mark.asyncio
+    async def test_a_hex_string_out_path_never_costs_the_reply(self):
+        """``contact_store`` persists paths as hex strings, so an app wiring the
+        stored value straight through hands this a str. ``bytes(str)`` raises,
+        which pre-guard unwound past the reply entirely."""
+        path_len = PathUtils.encode_path_len(1, 2)
+        self.handler.get_out_path = lambda _ident: ("1122", path_len)
+
+        await self.handler(self._build_login_packet(route_type="direct"))
+
+        assert len(self.sent_packets) == 1
+        response_pkt, _ = self.sent_packets[0]
+        assert response_pkt.is_route_flood()
+        response_pkt.write_to()
+
+    @pytest.mark.asyncio
+    async def test_a_non_integer_out_path_len_never_costs_the_reply(self):
+        """``int(raw_path_len)`` is just as able to raise as the buffer is."""
+        self.handler.get_out_path = lambda _ident: (b"\x11\x22", object())
+
+        await self.handler(self._build_login_packet(route_type="direct"))
+
+        assert len(self.sent_packets) == 1
+        assert self.sent_packets[0][0].is_route_flood()
+
+    @pytest.mark.asyncio
+    async def test_an_unencodable_out_path_len_falls_back_to_flood(self):
+        """A length that does not decode is not a route.
+
+        0xC1 is the case that isolates the ``is_valid_path_len`` gate from the
+        buffer-length check that follows it: hash_size 4 is reserved, so the
+        byte is invalid, but it declares 1 hop x 4 bytes and a 4-byte buffer
+        satisfies the length test. Without the gate this would put a reserved
+        path_len encoding on the air. A length like 0xFF is rejected by either
+        check and so proves neither.
+        """
+        self.handler.get_out_path = lambda _ident: (b"\x11\x22\x33\x44", 0xC1)
+
+        await self.handler(self._build_login_packet(route_type="direct"))
+
+        assert len(self.sent_packets) == 1
+        assert self.sent_packets[0][0].is_route_flood()
+
+    @pytest.mark.asyncio
+    async def test_a_raising_clear_out_path_never_costs_the_path_return(self):
+        """The clear is best-effort housekeeping for the *next* request. It must
+        not take down the PATH return this flood login is owed."""
+
+        def _boom(_ident):
+            raise RuntimeError("ACL exploded")
+
+        self.handler.clear_out_path = _boom
+
+        await self.handler(self._build_login_packet(route_type="flood"))
+
+        assert len(self.sent_packets) == 1
+        assert self.sent_packets[0][0].get_payload_type() == PAYLOAD_TYPE_PATH
+
+    @pytest.mark.asyncio
+    async def test_get_out_path_is_asked_by_full_public_key(self):
+        """Firmware looks the client up by full pub_key, not the 1-byte hash a
+        dest-hash collision would share. The callback gets the Identity."""
+        seen = []
+        self.handler.get_out_path = lambda ident: seen.append(ident) or None
+
+        await self.handler(self._build_login_packet(route_type="direct"))
+
+        assert len(seen) == 1
+        assert seen[0].get_public_key() == self.client_identity_local.get_public_key()
+
     @pytest.mark.asyncio
     async def test_flood_login_response_decryptable_with_login_reply(self):
         """PATH response from flood login contains the 13-byte login reply as extra data."""

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -2043,9 +2043,11 @@ class TestLoginServerHandler:
     """
     Tests for the server-side login handler.
 
-    Validates that behavior matches C++ MeshCore/examples/simple_repeater:
+    Validates that behavior matches C++ MeshCore/examples/simple_repeater
+    (1.17.1 #3106 / chooseReplyRoute):
     - Flood login → PATH packet response (login reply as extra data)
-    - Direct login → RESPONSE datagram flooded back
+    - Direct login + no stored out_path → RESPONSE datagram flooded back
+    - Direct login + stored ACL out_path → RESPONSE datagram sent DIRECT
     - Failed auth → no response sent
     - Response payload is 13 bytes with correct structure
     """
@@ -2176,7 +2178,7 @@ class TestLoginServerHandler:
 
     @pytest.mark.asyncio
     async def test_direct_login_sends_response_datagram(self):
-        """Direct login: RESPONSE datagram via flood (C++ sendFlood/createDatagram)."""
+        """Direct login with no stored out_path: RESPONSE datagram via flood."""
         pkt = self._build_login_packet(password="admin123", route_type="direct")
         await self.handler(pkt)
 
@@ -2188,8 +2190,76 @@ class TestLoginServerHandler:
         # Must be PAYLOAD_TYPE_RESPONSE — regular datagram, NOT a PATH packet
         assert response_pkt.get_payload_type() == PAYLOAD_TYPE_RESPONSE
 
-        # C++ sends the datagram via flood when reply_path_len < 0
+        # Firmware chooseReplyRoute: direct + no out_path → REPLY_ROUTE_FLOOD
         assert response_pkt.is_route_flood()
+
+    @pytest.mark.asyncio
+    async def test_direct_login_with_stored_out_path_sends_direct(self):
+        """Direct login + stored ACL out_path → sendDirect (firmware #3106)."""
+        path = bytes([0x11, 0x22])
+        path_len = PathUtils.encode_path_len(1, 2)
+        self.handler.get_out_path = lambda _ident: (path, path_len)
+
+        pkt = self._build_login_packet(password="admin123", route_type="direct")
+        await self.handler(pkt)
+
+        assert len(self.sent_packets) == 1
+        response_pkt, delay_ms = self.sent_packets[0]
+        assert delay_ms == 300
+        assert response_pkt.get_payload_type() == PAYLOAD_TYPE_RESPONSE
+        assert response_pkt.is_route_direct()
+        assert bytes(response_pkt.path) == path
+        assert response_pkt.path_len == path_len
+
+    @pytest.mark.asyncio
+    async def test_direct_login_trims_stored_out_path_to_declared_length(self):
+        """Trailing storage bytes are not copied into the serialized route."""
+        path_len = PathUtils.encode_path_len(1, 2)
+        self.handler.get_out_path = lambda _ident: (b"\x11\x22\x33", path_len)
+
+        await self.handler(self._build_login_packet(route_type="direct"))
+
+        response_pkt, _ = self.sent_packets[0]
+        assert response_pkt.is_route_direct()
+        assert bytes(response_pkt.path) == b"\x11\x22"
+        response_pkt.write_to()
+
+    @pytest.mark.asyncio
+    async def test_direct_login_with_short_stored_out_path_falls_back_to_flood(self):
+        """A corrupt ACL path must not suppress an otherwise valid login reply."""
+        path_len = PathUtils.encode_path_len(2, 2)
+        self.handler.get_out_path = lambda _ident: (b"\x11\x22", path_len)
+
+        await self.handler(self._build_login_packet(route_type="direct"))
+
+        response_pkt, _ = self.sent_packets[0]
+        assert response_pkt.is_route_flood()
+        response_pkt.write_to()
+
+    @pytest.mark.asyncio
+    async def test_direct_login_zero_hop_out_path_sends_direct(self):
+        """out_path_len == 0 is a known neighbour, not OUT_PATH_UNKNOWN."""
+        self.handler.get_out_path = lambda _ident: (b"", 0)
+
+        pkt = self._build_login_packet(password="admin123", route_type="direct")
+        await self.handler(pkt)
+
+        response_pkt, _ = self.sent_packets[0]
+        assert response_pkt.is_route_direct()
+        assert response_pkt.path_len == 0
+
+    @pytest.mark.asyncio
+    async def test_flood_login_clears_stored_out_path(self):
+        """Flood login asks the app to forget out_path (firmware OUT_PATH_UNKNOWN)."""
+        cleared = []
+        self.handler.clear_out_path = lambda ident: cleared.append(ident.get_public_key())
+
+        pkt = self._build_login_packet(password="admin123", route_type="flood")
+        await self.handler(pkt)
+
+        assert len(cleared) == 1
+        assert cleared[0] == self.client_identity_local.get_public_key()
+        assert self.sent_packets[0][0].get_payload_type() == PAYLOAD_TYPE_PATH
 
     @pytest.mark.asyncio
     async def test_flood_login_response_decryptable_with_login_reply(self):
@@ -2402,12 +2472,12 @@ class TestLoginServerHandler:
 
     @pytest.mark.asyncio
     async def test_direct_login_flood_reply_accumulates_at_request_hash_width(self):
-        """The direct-login flood RESPONSE mirrors the width too.
+        """The no-out_path direct-login flood RESPONSE mirrors the width too.
 
-        Firmware runs this branch through the same sendFloodReply(...,
-        packet->getPathHashSize()) call (simple_repeater onAnonDataRecv, the
-        ``reply_path_len < 0`` case). A direct request that reached us has had
-        its hops consumed but still carries the width in path_len bits 6-7.
+        Firmware chooseReplyRoute FLOOD (no stored out_path) still goes through
+        sendFloodReply(..., packet->getPathHashSize()). A direct request that
+        reached us has had its hops consumed but still carries the width in
+        path_len bits 6-7.
         """
         pkt = self._build_login_packet(password="admin123", route_type="direct")
         pkt.path_len = PathUtils.encode_path_len(3, 0)  # 3-byte hashes, hops consumed

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -2251,8 +2251,8 @@ class TestLoginServerHandler:
     @pytest.mark.asyncio
     async def test_zero_hop_out_path_keeps_its_declared_width(self):
         """A direct reply is a ``sendDirect``, which firmware never routes
-        through ``sendFloodReply`` -- so it must not be re-stamped with the
-        request's path-hash width, nor handed to the reply-scope helper.
+        through ``sendFloodReply``, so it must not be re-stamped with the
+        request's path-hash width.
 
         Only zero hops can show this: ``apply_path_hash_mode`` returns early
         once ``get_path_hash_count()`` is non-zero, so a multi-hop stored route
@@ -2260,6 +2260,10 @@ class TestLoginServerHandler:
         stored route is a direct neighbour, so dropping the ``is_route_flood()``
         guard rewrites the reply's ``path_len`` from 0 to ``encode_path_len(2,
         0)`` -- a width the stored route never had.
+
+        The guard also withholds the reply from ``apply_reply_scope``, which
+        this does *not* prove: on a DIRECT request that call is a no-op either
+        way, so no assertion here can distinguish it.
         """
         self.handler.get_out_path = lambda _ident: (b"", 0)
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -2249,6 +2249,30 @@ class TestLoginServerHandler:
         assert response_pkt.path_len == 0
 
     @pytest.mark.asyncio
+    async def test_zero_hop_out_path_keeps_its_declared_width(self):
+        """A direct reply is a ``sendDirect``, which firmware never routes
+        through ``sendFloodReply`` -- so it must not be re-stamped with the
+        request's path-hash width, nor handed to the reply-scope helper.
+
+        Only zero hops can show this: ``apply_path_hash_mode`` returns early
+        once ``get_path_hash_count()`` is non-zero, so a multi-hop stored route
+        is untouched either way. Here the request carries 2-byte hashes and the
+        stored route is a direct neighbour, so dropping the ``is_route_flood()``
+        guard rewrites the reply's ``path_len`` from 0 to ``encode_path_len(2,
+        0)`` -- a width the stored route never had.
+        """
+        self.handler.get_out_path = lambda _ident: (b"", 0)
+
+        pkt = self._build_login_packet(route_type="direct", path=b"\xaa\xbb")
+        pkt.path_len = PathUtils.encode_path_len(2, 1)  # 1 hop, 2-byte hashes
+
+        await self.handler(pkt)
+
+        response_pkt, _ = self.sent_packets[0]
+        assert response_pkt.is_route_direct()
+        assert response_pkt.path_len == 0
+
+    @pytest.mark.asyncio
     async def test_flood_login_clears_stored_out_path(self):
         """Flood login asks the app to forget out_path (firmware OUT_PATH_UNKNOWN)."""
         cleared = []

--- a/tests/test_region_map.py
+++ b/tests/test_region_map.py
@@ -232,6 +232,26 @@ class TestCaptureRecvRegion:
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
 
+    def test_a_second_capture_keeps_the_first_region(self):
+        """Firmware captures ``recv_pkt_region`` once, in onRecvPacket.
+
+        A Packet here reaches two entrypoints -- the dispatcher, then a
+        CompanionBridge the host delegates it to -- with awaits and flood hold
+        time between them, and the repeater hot-reloads its RegionMap on a
+        transport-key change. A re-capture against the newer map would silently
+        replace a decision that was correct when the packet arrived, and the
+        reply would drop to DEFAULT instead of mirroring its request.
+        """
+        key_a = get_auto_key_for("#region-a")
+        req = _make_scoped_packet("region-a")
+
+        capture_recv_region(RegionMap([RegionEntry(id=1, name="#region-a")]), req)
+        assert req._recv_region_key == key_a
+
+        # The shared map is rebuilt and no longer serves region A.
+        capture_recv_region(RegionMap(), req)
+        assert req._recv_region_key == key_a
+
     def test_allowed_wildcard_flood_is_mirrored_as_unscoped(self):
         """An allowed wildcard means the requester chose un-scoped. That is a
         decision, so it is marked final and a node default cannot override it."""

--- a/tests/test_region_map.py
+++ b/tests/test_region_map.py
@@ -204,9 +204,10 @@ class TestApplyReplyScopeDefault:
         ``sendFloodScoped(recipient, ...)`` prefers ``send_scope`` over
         ``default_scope``. Firmware's *repeater* has no override concept, so
         with no default configured its ``sendFloodReply`` would send this reply
-        plain. No topology here reaches that state -- CompanionBridge never
-        writes these dispatcher fields, and a CompanionRadio owns its own
-        dispatcher, where honouring the override is correct.
+        plain. This test pins the behaviour openhop actually has; the claim
+        that no shipped topology reaches it lives in the apply_reply_scope
+        docstring, and is an argument about wiring rather than something a unit
+        test can establish.
         """
         override = get_auto_key_for("#override-region")
         req = Packet()
@@ -256,15 +257,16 @@ class TestCaptureRecvRegion:
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
 
-    def test_a_second_capture_keeps_the_first_region(self):
-        """Firmware captures ``recv_pkt_region`` once, in onRecvPacket.
+    def test_a_capture_that_decided_survives_a_later_one(self):
+        """A resolved capture is a decision and must not be re-run.
 
-        A Packet here reaches two entrypoints -- the dispatcher, then a
-        CompanionBridge the host delegates it to -- with awaits and flood hold
-        time between them, and the repeater hot-reloads its RegionMap on a
-        transport-key change. A re-capture against the newer map would silently
-        replace a decision that was correct when the packet arrived, and the
-        reply would drop to DEFAULT instead of mirroring its request.
+        Two entrypoints can capture the same Packet -- the dispatcher, then a
+        CompanionBridge the host delegates it to -- and the repeater hot-reloads
+        its RegionMap on a transport-key change. Re-capturing against the newer
+        map would replace an answer that was correct when the packet arrived,
+        dropping the reply to DEFAULT instead of mirroring its request. Calls
+        the helper directly; the two-entrypoint wiring itself is covered by
+        TestRegionCaptureBothEntrypoints in test_flood_scope_fix.py.
         """
         key_a = get_auto_key_for("#region-a")
         req = _make_scoped_packet("region-a")
@@ -272,9 +274,65 @@ class TestCaptureRecvRegion:
         capture_recv_region(RegionMap([RegionEntry(id=1, name="#region-a")]), req)
         assert req._recv_region_key == key_a
 
-        # The shared map is rebuilt and no longer serves region A.
+        # The map is rebuilt and no longer serves region A.
         capture_recv_region(RegionMap(), req)
         assert req._recv_region_key == key_a
+
+    def test_an_unscoped_capture_also_counts_as_decided(self):
+        """Mirroring an un-scoped request is a decision too, not an absence of
+        one, so it is equally protected from a later capture."""
+        req = Packet()
+        req.header = ROUTE_TYPE_FLOOD
+
+        capture_recv_region(RegionMap(), req)
+        assert req._recv_region_unscoped is True
+
+        denying = RegionMap()
+        denying.wildcard.flags |= REGION_DENY_FLOOD
+        capture_recv_region(denying, req)
+        assert req._recv_region_unscoped is True
+
+    def test_a_capture_that_resolved_nothing_does_not_block_another_map(self):
+        """Resolving nothing is not a decision.
+
+        A bridge may serve regions its host dispatcher does not. When the first
+        capture could not match the transport code, the second entrypoint's own
+        map must still get to try -- otherwise the reply defers to DEFAULT when
+        a request scope was in fact knowable.
+        """
+        key_b = get_auto_key_for("#region-b")
+        req = _make_scoped_packet("region-b")
+
+        capture_recv_region(RegionMap([RegionEntry(id=1, name="#region-a")]), req)
+        assert req._recv_region_captured is True
+        assert req._recv_region_key is None  # map A cannot resolve it
+
+        capture_recv_region(RegionMap([RegionEntry(id=2, name="#region-b")]), req)
+        assert req._recv_region_key == key_b
+
+    def test_reparsing_a_packet_clears_a_previous_frames_capture(self):
+        """A reused Packet must not carry a decision into the next frame.
+
+        ``read_from`` repopulates every wire field, so any in-memory decision
+        about the previous frame is stale: a surviving capture would have the
+        next reply mirror a region this frame never arrived under, and a
+        surviving ``_flood_scope_applied`` would make both send-layer resolvers
+        skip a packet they have never seen.
+        """
+        scoped = _make_scoped_packet("region-a")
+        capture_recv_region(RegionMap([RegionEntry(id=1, name="#region-a")]), scoped)
+        scoped._flood_scope_applied = True
+        assert scoped._recv_region_key is not None
+
+        plain = PacketBuilder.create_advert(
+            local_identity=LocalIdentity(), name="y", route_type="flood"
+        )
+        scoped.read_from(plain.write_to())
+
+        assert scoped._recv_region_captured is False
+        assert scoped._recv_region_key is None
+        assert scoped._recv_region_unscoped is False
+        assert scoped._flood_scope_applied is False
 
     def test_allowed_wildcard_flood_is_mirrored_as_unscoped(self):
         """An allowed wildcard means the requester chose un-scoped. That is a

--- a/tests/test_region_map.py
+++ b/tests/test_region_map.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from openhop_core.node.dispatcher import Dispatcher
 from openhop_core.protocol import LocalIdentity, Packet, PacketBuilder
 from openhop_core.protocol.constants import (
     ROUTE_TYPE_DIRECT,
@@ -101,49 +102,149 @@ class TestChooseReplyScope:
         assert choose_reply_scope(False, True, False) == REPLY_SCOPE_NONE
 
 
+class _MockRadio:
+    """Minimal radio so a Dispatcher can be built for its TX-time scoping."""
+
+    def set_rx_callback(self, callback):
+        pass
+
+    async def send(self, data: bytes) -> bool:
+        return True
+
+
+def _resolve_at_tx(reply, *, default_key=None, override=None, unscoped=False):
+    """Run a built reply through the send layer, as an actual TX would.
+
+    ``apply_reply_scope`` defers the DEFAULT case, so a test that wants to see
+    the resulting scope has to ask the layer that decides it.
+    """
+    dispatcher = Dispatcher(_MockRadio())
+    dispatcher.default_flood_transport_key = default_key
+    dispatcher.flood_transport_key = override
+    dispatcher.flood_unscoped = unscoped
+    dispatcher._apply_flood_scope(reply)
+    return reply
+
+
+def _flood_reply():
+    return PacketBuilder.create_advert(local_identity=LocalIdentity(), name="x", route_type="flood")
+
+
 class TestApplyReplyScopeDefault:
-    def test_direct_request_uses_captured_default_key(self):
+    """REPLY_SCOPE_DEFAULT is deferred to the send layer, not resolved here."""
+
+    def test_direct_request_defers_to_the_send_layer(self):
+        """A DIRECT request carries no transport codes, so its scope is
+        unknowable. The helper must leave the reply unmarked so the ordinary
+        precedence runs -- marking it would suppress that chain entirely."""
+        req = Packet()
+        req.header = ROUTE_TYPE_DIRECT
+        capture_recv_region(RegionMap(), req)
+
+        reply = _flood_reply()
+        apply_reply_scope(reply, req)
+
+        assert reply._flood_scope_applied is False
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+
+    def test_deferred_direct_request_then_takes_the_node_default(self):
+        """Firmware's repeater answers this case with
+        ``sendFloodScoped(default_scope, ...)``; here the same key arrives via
+        the send layer. This is the behaviour MeshCore PR #3106 added -- an
+        un-scoped reply is dropped at hop 0 by ``flood.max.unscoped=0``."""
         default_key = get_auto_key_for("#default-region")
         req = Packet()
         req.header = ROUTE_TYPE_DIRECT
-        req._recv_region_captured = True
-        req._recv_region_key = None
-        req._recv_default_scope_key = default_key
+        capture_recv_region(RegionMap(), req)
 
-        reply = PacketBuilder.create_advert(
-            local_identity=LocalIdentity(), name="x", route_type="flood"
-        )
+        reply = _flood_reply()
         apply_reply_scope(reply, req)
+        _resolve_at_tx(reply, default_key=default_key)
+
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
-        assert reply._flood_scope_applied is True
+
+    def test_deferred_direct_request_honours_explicit_unscoped(self):
+        """A node told to force un-scoped floods keeps doing so. Firmware's
+        companion overload checks ``send_unscoped`` before any scope; resolving
+        DEFAULT inside the helper would silently override the operator."""
+        default_key = get_auto_key_for("#default-region")
+        req = Packet()
+        req.header = ROUTE_TYPE_DIRECT
+        capture_recv_region(RegionMap(), req)
+
+        reply = _flood_reply()
+        apply_reply_scope(reply, req)
+        _resolve_at_tx(reply, default_key=default_key, unscoped=True)
+
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+        assert reply.transport_codes == [0, 0]
+
+    def test_deferred_direct_request_honours_the_transient_override(self):
+        """``send_scope`` beats ``default_scope`` in firmware's companion
+        overload, so the reply must carry the override, not the default."""
+        default_key = get_auto_key_for("#default-region")
+        override = get_auto_key_for("#override-region")
+        req = Packet()
+        req.header = ROUTE_TYPE_DIRECT
+        capture_recv_region(RegionMap(), req)
+
+        reply = _flood_reply()
+        apply_reply_scope(reply, req)
+        _resolve_at_tx(reply, default_key=default_key, override=override)
+
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(override, reply)
+
+    def test_deferred_direct_request_with_no_scope_stays_plain(self):
+        """Firmware's final ``REPLY_SCOPE_NONE``: nothing configured, so the
+        reply goes out a plain flood."""
+        req = Packet()
+        req.header = ROUTE_TYPE_DIRECT
+        capture_recv_region(RegionMap(), req)
+
+        reply = _flood_reply()
+        apply_reply_scope(reply, req)
+        _resolve_at_tx(reply)
+
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
 
 
 class TestCaptureRecvRegion:
-    def test_second_capture_without_default_preserves_dispatcher_snapshot(self):
-        """Bridge delegation must not erase a default captured by the dispatcher."""
-        default_key = get_auto_key_for("#default-region")
-        req = Packet()
-        req.header = ROUTE_TYPE_DIRECT
-
-        capture_recv_region(RegionMap(), req, default_key=default_key)
-        capture_recv_region(RegionMap(), req, default_key=None)
-
-        assert req._recv_default_scope_key == default_key
-
-    def test_plain_flood_uses_default_when_wildcard_denies_flood(self):
+    def test_wildcard_denying_flood_makes_the_scope_unknowable(self):
+        """Firmware leaves ``recv_pkt_region`` NULL when the wildcard denies
+        FLOOD, which is *unknowable*, not *un-scoped*: the reply must defer
+        rather than mirror the request as plain."""
         default_key = get_auto_key_for("#default-region")
         region_map = RegionMap()
         region_map.wildcard.flags |= REGION_DENY_FLOOD
         req = Packet()
         req.header = ROUTE_TYPE_FLOOD
 
-        capture_recv_region(region_map, req, default_key=default_key)
+        capture_recv_region(region_map, req)
         assert req._recv_region_unscoped is False
 
-        reply = PacketBuilder.create_advert(
-            local_identity=LocalIdentity(), name="x", route_type="flood"
-        )
+        reply = _flood_reply()
         apply_reply_scope(reply, req)
+        assert reply._flood_scope_applied is False
+
+        _resolve_at_tx(reply, default_key=default_key)
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
+
+    def test_allowed_wildcard_flood_is_mirrored_as_unscoped(self):
+        """An allowed wildcard means the requester chose un-scoped. That is a
+        decision, so it is marked final and a node default cannot override it."""
+        default_key = get_auto_key_for("#default-region")
+        req = Packet()
+        req.header = ROUTE_TYPE_FLOOD
+
+        capture_recv_region(RegionMap(), req)
+        assert req._recv_region_unscoped is True
+
+        reply = _flood_reply()
+        apply_reply_scope(reply, req)
+        assert reply._flood_scope_applied is True
+
+        _resolve_at_tx(reply, default_key=default_key)
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD

--- a/tests/test_region_map.py
+++ b/tests/test_region_map.py
@@ -3,8 +3,22 @@
 from __future__ import annotations
 
 from openhop_core.protocol import LocalIdentity, Packet, PacketBuilder
-from openhop_core.protocol.constants import ROUTE_TYPE_TRANSPORT_FLOOD
-from openhop_core.protocol.region_map import REGION_DENY_FLOOD, RegionEntry, RegionMap
+from openhop_core.protocol.constants import (
+    ROUTE_TYPE_DIRECT,
+    ROUTE_TYPE_FLOOD,
+    ROUTE_TYPE_TRANSPORT_FLOOD,
+)
+from openhop_core.protocol.region_map import (
+    REGION_DENY_FLOOD,
+    REPLY_SCOPE_DEFAULT,
+    REPLY_SCOPE_NONE,
+    REPLY_SCOPE_REQUEST,
+    RegionEntry,
+    RegionMap,
+    apply_reply_scope,
+    capture_recv_region,
+    choose_reply_scope,
+)
 from openhop_core.protocol.transport_keys import calc_transport_code, get_auto_key_for
 
 
@@ -67,3 +81,69 @@ class TestRegionMapMatching:
         # With REGION_DENY_FLOOD mask, denied region is skipped → no match.
         match_filtered = rmap.find_match(pkt, mask=REGION_DENY_FLOOD)
         assert match_filtered is None
+
+
+class TestChooseReplyScope:
+    """Firmware RoutingPolicy.h chooseReplyScope vectors."""
+
+    def test_mirrors_known_request_scope(self):
+        assert choose_reply_scope(True, False, False) == REPLY_SCOPE_REQUEST
+        assert choose_reply_scope(True, False, True) == REPLY_SCOPE_REQUEST
+
+    def test_unscoped_flood_stays_none_even_with_default(self):
+        assert choose_reply_scope(False, True, True) == REPLY_SCOPE_NONE
+
+    def test_falls_back_to_default_when_request_scope_unknown(self):
+        assert choose_reply_scope(False, False, True) == REPLY_SCOPE_DEFAULT
+
+    def test_none_when_no_scope_available(self):
+        assert choose_reply_scope(False, False, False) == REPLY_SCOPE_NONE
+        assert choose_reply_scope(False, True, False) == REPLY_SCOPE_NONE
+
+
+class TestApplyReplyScopeDefault:
+    def test_direct_request_uses_captured_default_key(self):
+        default_key = get_auto_key_for("#default-region")
+        req = Packet()
+        req.header = ROUTE_TYPE_DIRECT
+        req._recv_region_captured = True
+        req._recv_region_key = None
+        req._recv_default_scope_key = default_key
+
+        reply = PacketBuilder.create_advert(
+            local_identity=LocalIdentity(), name="x", route_type="flood"
+        )
+        apply_reply_scope(reply, req)
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
+        assert reply._flood_scope_applied is True
+
+
+class TestCaptureRecvRegion:
+    def test_second_capture_without_default_preserves_dispatcher_snapshot(self):
+        """Bridge delegation must not erase a default captured by the dispatcher."""
+        default_key = get_auto_key_for("#default-region")
+        req = Packet()
+        req.header = ROUTE_TYPE_DIRECT
+
+        capture_recv_region(RegionMap(), req, default_key=default_key)
+        capture_recv_region(RegionMap(), req, default_key=None)
+
+        assert req._recv_default_scope_key == default_key
+
+    def test_plain_flood_uses_default_when_wildcard_denies_flood(self):
+        default_key = get_auto_key_for("#default-region")
+        region_map = RegionMap()
+        region_map.wildcard.flags |= REGION_DENY_FLOOD
+        req = Packet()
+        req.header = ROUTE_TYPE_FLOOD
+
+        capture_recv_region(region_map, req, default_key=default_key)
+        assert req._recv_region_unscoped is False
+
+        reply = PacketBuilder.create_advert(
+            local_identity=LocalIdentity(), name="x", route_type="flood"
+        )
+        apply_reply_scope(reply, req)
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(default_key, reply)

--- a/tests/test_region_map.py
+++ b/tests/test_region_map.py
@@ -196,6 +196,30 @@ class TestApplyReplyScopeDefault:
         assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert reply.transport_codes[0] == calc_transport_code(override, reply)
 
+    def test_no_default_but_an_override_takes_the_override(self):
+        """Recorded divergence, not an accident.
+
+        Rows 3/4 reach a precedence that also honours the transient override,
+        because the companion role requires it: firmware's
+        ``sendFloodScoped(recipient, ...)`` prefers ``send_scope`` over
+        ``default_scope``. Firmware's *repeater* has no override concept, so
+        with no default configured its ``sendFloodReply`` would send this reply
+        plain. No topology here reaches that state -- CompanionBridge never
+        writes these dispatcher fields, and a CompanionRadio owns its own
+        dispatcher, where honouring the override is correct.
+        """
+        override = get_auto_key_for("#override-region")
+        req = Packet()
+        req.header = ROUTE_TYPE_DIRECT
+        capture_recv_region(RegionMap(), req)
+
+        reply = _flood_reply()
+        apply_reply_scope(reply, req)
+        _resolve_at_tx(reply, default_key=None, override=override)
+
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(override, reply)
+
     def test_deferred_direct_request_with_no_scope_stays_plain(self):
         """Firmware's final ``REPLY_SCOPE_NONE``: nothing configured, so the
         reply goes out a plain flood."""


### PR DESCRIPTION
Ports MeshCore PR #3106 (`chooseReplyScope` DEFAULT fallback, and direct-login
`out_path` routing), plus the two companion frame errors from the same parity
pass.

## What changes

**Reply scope.** `chooseReplyScope` was two-way here: mirror the request's
region, else send plain. Firmware is four-way, and the missing arm is the one
#3106 added — when the request's scope is unknowable (it arrived DIRECT so
carries no transport codes, or its code matched no Region), the reply goes out
under the node's default region. Un-scoped is dropped at hop 0 by any repeater
running `flood.max.unscoped=0`.

`apply_reply_scope` decides the two arms the RX capture can answer on its own
and leaves the other two to the send layer. Firmware splits that case by role:
a repeater resolves it as `sendFloodScoped(default_scope, ...)`, while a
companion answers the same case with `sendFloodScoped(recipient, ...)`, which is
`send_unscoped` first, then `send_scope`, else `default_scope`. One helper here
serves both roles, and `Dispatcher._apply_flood_scope` /
`CompanionBase._apply_flood_scope` already do exactly that precedence. Deciding
it in the helper would duplicate that chain and, by marking the packet, suppress
it — an operator's explicit-unscoped flag and transient scope override would
both be overridden.

`RegionMap` grows the wildcard Region firmware keeps outside its region list, so
"arrived un-scoped" can be told apart from "unknowable".

**Direct-login reply route.** A DIRECT login was always answered by flooding.
`LoginServerHandler` now takes optional `get_out_path` / `clear_out_path`
callbacks and replies DIRECT along a stored path when it has one, as
`ProtocolRequestHandler` already did for REQ. It also ports the invalidation
this depends on: firmware's `handleLoginReq` clears a client's `out_path` when
the login arrives by flood. `CompanionBridge` wires both to its contact store.
Without the callbacks the behaviour is unchanged.

`out_path` and `out_path_len` come from the application rather than firmware's
fixed `ClientInfo`, so the whole lookup is guarded and falls back to flooding. A
bad ACL entry costs the direct route, never the reply.

**Companion frame errors.** `SEND_RAW_PACKET` parse failure now maps to
`ERR_CODE_ILLEGAL_ARG` rather than `TABLE_FULL` (`send_raw_packet` returns a
`SentResult` so the handler can tell parse failure from a full TX queue), and
`SEND_RAW_DATA` with a valid path but a payload short of 4 bytes maps to
`ILLEGAL_ARG`.

## Two fixes found while testing this

Both predate the branch; the deferral above makes the first reachable more often.

- `capture_recv_region` was not idempotent. A Packet reaches two entrypoints —
  the dispatcher, then a `CompanionBridge` the host delegates it to — and the
  repeater rebuilds its `RegionMap` on a transport-key change, so the second
  capture could replace a decision that was correct when the packet arrived. A
  capture that reached a decision now stands. One that resolved nothing does
  not block a second entrypoint whose own map may resolve the code.
- `CompanionBase._apply_flood_scope` set `_flood_scope_applied` but never read
  it, unlike `Dispatcher._apply_flood_scope`. A reply deliberately left plain
  could be scoped anyway on the way out. It now returns early on the mark. No
  existing caller is affected: each builds its packet immediately before
  resolving it.

`Packet.read_from` also now clears the RX capture and both applied-markers, so a
reused Packet cannot carry one frame's decision into the next.

## Checks

1736 tests pass on Python 3.12. Every guard added here was checked by removing
it and confirming a specific test fails.

Behaviour was compared against firmware `dev` at `65aa1138`, not just the
docstrings:

- All six `chooseReplyScope` vectors from firmware's own
  `test/test_routing_policy/test_routing_policy.cpp` match `choose_reply_scope`.
- All four `chooseReplyRoute` rows a login can reach match `LoginServerHandler`,
  including the clear-on-flood.
- All ten capture + reply-scope cases match `onRecvPacket` + `sendFloodReply` on
  a repeater-shaped node.

`RoutingPolicy.h` has not changed since this work started.

## Known difference

The deferred arms reach a precedence that also honours the transient override
and the explicit-unscoped flag, because the companion role needs it. Firmware's
repeater has neither, so a node holding a `RegionMap` and an override but no
default would scope a reply firmware's repeater sends plain. No wiring here
reaches that state — `CompanionBridge` never writes those dispatcher fields, and
a `CompanionRadio` owns its own dispatcher, where honouring them is correct. A
test records the behaviour.
