### PR TITLE
fix(node): give every ACK waiter its own event

### DIFF
--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -189,7 +189,9 @@ class Dispatcher:
         self._logger = logging.getLogger("Dispatcher")
         self._current_expected_crc: Optional[int] = None
         self._recent_acks: dict[int, float] = {}  # {crc: timestamp}
-        self._waiting_acks = {}
+        # {crc: [event per waiter]} -- see expect_ack for why waiters are not
+        # coalesced onto one shared Event.
+        self._waiting_acks: dict[int, list[asyncio.Event]] = {}
         self.dedupe_enabled = dedupe_enabled
 
         # Simple TX lock to prevent concurrent transmissions
@@ -1093,10 +1095,10 @@ class Dispatcher:
             # is the one that spans every exit path. Without this, a cancel during
             # the tx_delay pause would strand the CRC in _waiting_acks forever
             # (nothing prunes it, unlike _recent_acks), leaving relayed ACKs for
-            # that CRC permanently marked do-not-retransmit. Identity-guarded and
-            # idempotent: a no-op once the ACK path or _await_ack_event removed it.
-            if self._waiting_acks.get(ack_crc) is ack_event:
-                del self._waiting_acks[ack_crc]
+            # that CRC permanently marked do-not-retransmit. Scoped to our own
+            # Event and idempotent: a no-op once the ACK path or
+            # _await_ack_event removed it, and never another waiter's entry.
+            self._discard_ack_waiter(ack_crc, ack_event)
 
     def _resolve_tx_radio_id_for_log(
         self, raw: bytes, radio_id: Optional[str] = None
@@ -1257,12 +1259,11 @@ class Dispatcher:
             return False
         finally:
             # Clean up our registration on every exit path (normal return,
-            # timeout, or cancellation) so `_waiting_acks` never leaks.
-            # Identity-guarded: if the receive path already popped our entry
-            # (the normal-ACK case) this is a no-op; if a *different* waiter
-            # has since registered under the same CRC, don't delete theirs.
-            if self._waiting_acks.get(crc) is event:
-                del self._waiting_acks[crc]
+            # timeout, or cancellation) so `_waiting_acks` never leaks. Scoped
+            # to our own Event: if the receive path already popped the CRC (the
+            # normal-ACK case) this is a no-op, and a concurrent waiter on the
+            # same CRC keeps its registration.
+            self._discard_ack_waiter(crc, event)
 
     # ------------------------------------------------------------------#
     # ACK tracking and management
@@ -1271,16 +1272,46 @@ class Dispatcher:
         """
         Register an ACK CRC we're waiting for and return an asyncio.Event
         that will be set as soon as the ACK arrives (or is already cached).
-        """
-        evt = self._waiting_acks.get(crc)
-        if evt is None:
-            evt = asyncio.Event()
-            self._waiting_acks[crc] = evt
 
-            # ACK might already be in the recent-ACK cache -> fire instantly
+        Every call gets its *own* Event, appended to this CRC's waiter list,
+        even when a waiter is already registered for the same CRC. Two sends
+        can legitimately collide on one CRC -- it hashes the timestamp, flags
+        and text with a key (PacketBuilder.create_text_message), so a caller
+        that supplies its own ``timestamp`` can reproduce it exactly -- and
+        their waits overlap because the ACK wait runs off ``_tx_lock``.
+
+        Handing both waiters one shared Event made whichever left first delete
+        the registration the other was still relying on: its cleanup checked
+        identity, but the object *was* identical, so the guard passed. The
+        second sender then never saw its ACK and reported a false delivery
+        failure. Per-waiter events make that identity check mean what it says.
+        """
+        evt = asyncio.Event()
+        self._waiting_acks.setdefault(crc, []).append(evt)
+
+        # ACK might already be in the recent-ACK cache -> fire instantly
         if crc in self._recent_acks:
             evt.set()
         return evt
+
+    def _discard_ack_waiter(self, crc: int, event: asyncio.Event) -> None:
+        """Remove one waiter's registration; drop the CRC with the last waiter.
+
+        Identity-scoped, so a co-waiter on the same CRC keeps its own entry.
+        The key has to disappear once the list empties: AckHandler decides
+        do-not-retransmit with ``crc in _waiting_acks`` (firmware
+        BaseChatMesh::onAckRecv), and a leftover empty list would read as a
+        waiter that is still there.
+        """
+        waiters = self._waiting_acks.get(crc)
+        if waiters is None:
+            return
+        for index, waiter in enumerate(waiters):
+            if waiter is event:
+                del waiters[index]
+                break
+        if not waiters:
+            del self._waiting_acks[crc]
 
     # RX path for every incoming packet
     async def _dispatch(self, pkt: Packet) -> None:
@@ -1379,10 +1410,12 @@ class Dispatcher:
         ts = asyncio.get_running_loop().time()
         self._recent_acks[crc] = ts
 
-        # Notify waiting sender if this CRC matches
-        if evt := self._waiting_acks.pop(crc, None):
+        # Notify every waiting sender on this CRC -- concurrent sends can
+        # share one, and each holds its own Event.
+        if waiters := self._waiting_acks.pop(crc, None):
             self._log(f"ACK matched! CRC {crc:08X}")
-            evt.set()
+            for evt in waiters:
+                evt.set()
 
         if self._ack_received_listener:
             return bool(await self._invoke_ack_listener(crc))

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -235,8 +235,7 @@ class TestDispatcherInitialization:
         assert PAYLOAD_TYPE_MULTIPART in dispatcher._handlers
 
         crc = 0x12345678
-        evt = asyncio.Event()
-        dispatcher._waiting_acks[crc] = evt
+        evt = dispatcher.expect_ack(crc)
 
         # wrapper byte (remaining=1, inner=ACK) + 4-byte CRC (little-endian 0x12345678)
         payload = bytes([(1 << 4) | PAYLOAD_TYPE_ACK]) + b"\x78\x56\x34\x12"
@@ -340,8 +339,7 @@ class TestDispatcherACKSystem:
         crc = 0x12345678
 
         # Start waiting for ACK
-        ack_event = asyncio.Event()
-        dispatcher._waiting_acks[crc] = ack_event
+        ack_event = dispatcher.expect_ack(crc)
 
         # Simulate receiving ACK
         await dispatcher._register_ack_received(crc)
@@ -357,7 +355,7 @@ class TestDispatcherACKSystem:
     async def test_ack_timeout_cleanup(self, dispatcher):
         """Test ACK timeout and cleanup."""
         crc = 0x12345678
-        dispatcher._waiting_acks[crc] = asyncio.Event()
+        dispatcher.expect_ack(crc)
 
         # Simulate the cleanup logic from run_forever without the infinite loop
         # Clean out old ACK CRCs (older than 5 seconds)
@@ -424,29 +422,75 @@ class TestDispatcherWaitForAckCleanup:
         assert crc not in dispatcher._waiting_acks
 
     @pytest.mark.asyncio
-    async def test_stale_waiter_does_not_remove_newer_registration(self, dispatcher):
-        """If a stale waiter's cleanup runs after a *different* Event has been
-        registered under the same CRC (e.g. a fresh wait_for_ack() call took
-        over that slot), the stale cleanup must be a no-op rather than
-        deleting the newer registration out from under it."""
+    async def test_expect_ack_gives_each_caller_its_own_event(self, dispatcher):
+        """Two registrations for one CRC must not be coalesced onto a shared
+        Event. Sharing is what let one waiter's identity-guarded cleanup delete
+        the other's registration: the guard passed because the object really
+        was the same one (issue #136)."""
         crc = 0xAABBCCDD
 
-        task = asyncio.create_task(dispatcher.wait_for_ack(crc, timeout=10))
-        await asyncio.sleep(0)  # let the task register
-        stale_event = dispatcher._waiting_acks[crc]
+        first = dispatcher.expect_ack(crc)
+        second = dispatcher.expect_ack(crc)
 
-        # Simulate a newer waiter taking over the same CRC slot.
-        newer_event = asyncio.Event()
-        dispatcher._waiting_acks[crc] = newer_event
-        assert stale_event is not newer_event
+        assert first is not second
+        assert dispatcher._waiting_acks[crc] == [first, second]
 
-        task.cancel()
+    @pytest.mark.asyncio
+    async def test_register_ack_received_wakes_every_waiter_on_the_crc(self, dispatcher):
+        """One ACK resolves every send waiting on that CRC, not just one."""
+        crc = 0xAABBCCDD
+        first = dispatcher.expect_ack(crc)
+        second = dispatcher.expect_ack(crc)
+
+        await dispatcher._register_ack_received(crc)
+
+        assert first.is_set()
+        assert second.is_set()
+        assert crc not in dispatcher._waiting_acks
+
+    @pytest.mark.asyncio
+    async def test_cancelled_waiter_does_not_detach_a_co_waiter(self, dispatcher):
+        """A waiter's cleanup must remove only its own Event. Cancelling the
+        first of two waiters on one CRC must leave the second registered and
+        still able to be woken by the ACK it is waiting for."""
+        crc = 0xAABBCCDD
+
+        first = asyncio.create_task(dispatcher.wait_for_ack(crc, timeout=10))
+        second = asyncio.create_task(dispatcher.wait_for_ack(crc, timeout=10))
+        await asyncio.sleep(0)  # let both tasks register
+        assert len(dispatcher._waiting_acks[crc]) == 2
+
+        first.cancel()
         with pytest.raises(asyncio.CancelledError):
-            await task
+            await first
 
-        # The stale task's finally-block cleanup must not have clobbered
-        # the newer registration.
-        assert dispatcher._waiting_acks.get(crc) is newer_event
+        assert len(dispatcher._waiting_acks[crc]) == 1
+
+        await dispatcher._register_ack_received(crc)
+        assert await second is True
+        assert crc not in dispatcher._waiting_acks
+
+    @pytest.mark.asyncio
+    async def test_waiter_timing_out_does_not_detach_a_longer_one(self, dispatcher):
+        """Cancellation is not the only way to leave early. Whichever waiter's
+        own deadline fires first runs the same cleanup, and in the field that
+        is the likelier trigger: the first sender's ACK_TIMEOUT expiring while
+        a later send on the same CRC still has time left on its own."""
+        crc = 0xAABBCCDD
+
+        impatient = asyncio.create_task(dispatcher.wait_for_ack(crc, timeout=0.01))
+        patient = asyncio.create_task(dispatcher.wait_for_ack(crc, timeout=10))
+        await asyncio.sleep(0)  # let both tasks register
+        assert len(dispatcher._waiting_acks[crc]) == 2
+
+        assert await impatient is False  # its window closes first
+
+        assert len(dispatcher._waiting_acks[crc]) == 1
+
+        # An ACK arriving inside the second waiter's window still reaches it.
+        await dispatcher._register_ack_received(crc)
+        assert await patient is True
+        assert crc not in dispatcher._waiting_acks
 
     @pytest.mark.asyncio
     async def test_normal_ack_receipt_still_works_and_cleans_up_once(self, dispatcher):

--- a/tests/test_path_ack_handler.py
+++ b/tests/test_path_ack_handler.py
@@ -1,4 +1,3 @@
-import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -305,8 +304,7 @@ async def test_path_handler_updates_matched_contact_sends_reciprocal_and_resolve
     dispatcher = Dispatcher(_CallbackRadio())
     dispatcher.local_identity = LOCAL_IDENTITY
     dispatcher.set_contact_book(contacts)
-    waiting = asyncio.Event()
-    dispatcher._waiting_acks[ack_crc] = waiting
+    waiting = dispatcher.expect_ack(ack_crc)
 
     ack_handler = AckHandler(lambda _message: None, dispatcher)
     ack_handler.set_ack_received_callback(dispatcher._register_ack_received)

--- a/tests/test_transit_direct_delivery.py
+++ b/tests/test_transit_direct_delivery.py
@@ -265,8 +265,7 @@ async def test_direct_ack_is_still_peeked_in_transit():
     assert PAYLOAD_TYPE_ACK not in d._local_delivery_types
 
     crc = 0x12345678
-    evt = asyncio.Event()
-    d._waiting_acks[crc] = evt
+    evt = d.expect_ack(crc)
 
     ack = _direct_pkt(
         PAYLOAD_TYPE_ACK, bytes([OTHER_HASH, 0xBB]), hops=2, payload=crc.to_bytes(4, "little")

--- a/tests/test_tx_lock_ack_scope.py
+++ b/tests/test_tx_lock_ack_scope.py
@@ -461,3 +461,108 @@ async def test_state_returns_to_idle_after_a_successful_ack_wait():
     assert await task is True
     assert d.state == DispatcherState.IDLE
     assert d._current_expected_crc is None
+
+
+# --------------------------------------------------------------------------- #
+# Waiter ownership when two sends collide on one CRC (issue #136)
+# --------------------------------------------------------------------------- #
+#
+# Releasing _tx_lock before the ACK wait (the fix these tests pin) is what lets
+# two sends wait on the same CRC at once. That is legitimate -- the CRC hashes
+# timestamp, flags and text with a key (PacketBuilder.create_text_message), so a
+# caller supplying its own timestamp reproduces it exactly, and a plain retry of
+# one packet does too. Each waiter must therefore own its registration: one
+# leaving, for any reason, must not detach the other.
+
+
+@pytest.mark.asyncio
+async def test_same_crc_sends_each_get_their_own_waiter():
+    d, radio = _make()
+    crc = 0x12345678
+
+    first = asyncio.create_task(d.send_packet(_txt(0), wait_for_ack=True, expected_crc=crc))
+    second = asyncio.create_task(d.send_packet(_txt(1), wait_for_ack=True, expected_crc=crc))
+    assert await _spin_until(lambda: radio.send_count == 2)
+
+    waiters = d._waiting_acks[crc]
+    assert len(waiters) == 2
+    assert waiters[0] is not waiters[1]  # not coalesced onto one shared Event
+
+    await d._register_ack_received(crc)
+    assert await first is True
+    assert await second is True
+
+
+@pytest.mark.asyncio
+async def test_cancelling_one_same_crc_send_leaves_the_other_waiting():
+    # Issue #136: cancelling one sender deleted the shared registration, so the
+    # ACK that arrived next was cached but woke nobody, and the surviving send
+    # reported a delivery failure it never had.
+    d, radio = _make()
+    crc = 0x12345678
+
+    first = asyncio.create_task(d.send_packet(_txt(0), wait_for_ack=True, expected_crc=crc))
+    second = asyncio.create_task(d.send_packet(_txt(1), wait_for_ack=True, expected_crc=crc))
+    assert await _spin_until(lambda: radio.send_count == 2)
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    # Only the cancelled sender's own registration is gone.
+    assert len(d._waiting_acks[crc]) == 1
+
+    await d._register_ack_received(crc)
+    assert await second is True
+    assert d._waiting_acks == {}
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_tx_delay_spares_a_co_waiter():
+    # The send_packet finally-block owns cleanup for a cancel landing in the
+    # tx_delay gap, before _await_ack_event's own try/finally is entered
+    # (test_cancel_during_tx_delay_does_not_strand_the_waiter). That earlier
+    # cleanup path must be waiter-scoped too, not just the later one.
+    d, radio = _make(tx_delay=0.5)
+    crc = 0x0BADF00D
+
+    first = asyncio.create_task(d.send_packet(_txt(0), wait_for_ack=True, expected_crc=crc))
+    assert await _spin_until(lambda: crc in d._waiting_acks)
+    second = asyncio.create_task(d.send_packet(_txt(1), wait_for_ack=True, expected_crc=crc))
+    assert await _spin_until(lambda: len(d._waiting_acks.get(crc, [])) == 2)
+
+    first.cancel()  # still parked in tx_delay, not yet inside _await_ack_event
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    assert len(d._waiting_acks[crc]) == 1
+
+    await d._register_ack_received(crc)
+    assert await second is True
+    assert d._waiting_acks == {}
+
+
+@pytest.mark.asyncio
+async def test_crc_stays_registered_until_the_last_waiter_leaves():
+    # AckHandler decides do-not-retransmit with `crc in _waiting_acks`
+    # (firmware BaseChatMesh::onAckRecv). One waiter leaving must not clear that
+    # while another send is still in flight, and the last one leaving must clear
+    # it -- an empty list left behind would read as a waiter that is still there
+    # and mark every relayed ACK for that CRC for the life of the process.
+    d, radio = _make()
+    crc = 0x0BADF00D
+
+    first = asyncio.create_task(d.send_packet(_txt(0), wait_for_ack=True, expected_crc=crc))
+    second = asyncio.create_task(d.send_packet(_txt(1), wait_for_ack=True, expected_crc=crc))
+    assert await _spin_until(lambda: radio.send_count == 2)
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    assert crc in d._waiting_acks  # second is still waiting on it
+
+    second.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await second
+    assert crc not in d._waiting_acks
+    assert d._waiting_acks == {}


### PR DESCRIPTION
expect_ack coalesced all waiters for a CRC onto one asyncio.Event, so two overlapping sends on the same expected CRC were handed the identical object. Both cleanup paths -- _await_ack_event's finally and send_packet's -- then deleted the registration on an identity check that could not tell the two apart, because there was only one event to compare. Whichever waiter left first, by cancellation or by its own ACK_TIMEOUT expiring, detached the other: the ACK that arrived next was cached in _recent_acks but woke nobody, and a send that was in fact delivered reported failure.

This needs no CRC collision to reach. The CRC hashes timestamp, flags and text with a key (create_text_message), so a caller supplying its own timestamp reproduces it exactly, and a plain retry of one packet does too. The waits overlap because the ACK wait runs off _tx_lock (c10b878) -- the concurrency that exposed this, and worth keeping.

expect_ack now returns a fresh Event per caller, appended to the CRC's waiter list; _register_ack_received sets every waiter on the CRC; _discard_ack_waiter removes only the caller's own, dropping the key with the last one so AckHandler's `crc in _waiting_acks` do-not-retransmit test still reads true only while a send really is waiting.

Fixes #136