### PR TITLE
fix(kiss): let only TX_DONE decide whether a DATA frame transmitted

### DIFF
--- a/src/openhop_core/hardware/kiss_modem_wrapper.py
+++ b/src/openhop_core/hardware/kiss_modem_wrapper.py
@@ -11,6 +11,7 @@ Protocol spec (frame format, SetHardware sub-commands, Data + RxMeta ordering):
 import asyncio
 import inspect
 import logging
+import os
 import random
 import struct
 import threading
@@ -184,7 +185,13 @@ HW_ERR_NO_CALLBACK = 0x03
 HW_ERR_MAC_FAILED = 0x04
 HW_ERR_UNKNOWN_CMD = 0x05
 HW_ERR_ENCRYPT_FAILED = 0x06
-# Emitted only on the DATA path when a transmit is already pending (single-slot modem TX).
+# Two unrelated conditions share this code. The modem emits it on the DATA path when a
+# transmit is already pending (single-slot modem TX), and -- since firmware moved its
+# host-bound writes to a 2-slot queue -- whenever that queue overflows, which is a
+# receive-side condition with no bearing on our transmit (kiss_modem_protocol.md:
+# "Radio TX busy, or host output queue full"). The two are indistinguishable on the wire,
+# so TX_BUSY is never a verdict on the in-flight frame; only TX_DONE is, and firmware
+# retains a TX_DONE until it can be queued rather than dropping it.
 HW_ERR_TX_BUSY = 0x07
 
 ERR_INVALID_LENGTH = HW_ERR_INVALID_LENGTH
@@ -357,6 +364,16 @@ class KissModemWrapper(LoRaRadio):
             self.radio_config.get("reconnect_max_delay_seconds", 15.0)
         )
         self._reconnect_max_attempts = int(self.radio_config.get("reconnect_max_attempts", 0))
+        # USB identity (vid, pid, serial) of the configured port, learned on the first
+        # successful open so a re-enumeration under a new node name can be followed.
+        self._port_identity_ref: Optional[tuple] = None
+        # Public key of the modem last handshaked, so a port that merely shares a
+        # vid/pid is not mistaken for this radio.
+        self._modem_identity_ref: Optional[bytes] = None
+        # Consecutive open failures sharing one (path, errno), for the wedged-port line.
+        self._open_failure_key: Optional[tuple] = None
+        self._open_failure_count = 0
+        self._open_failure_log_ts: Optional[float] = None
         self._post_connect_settle_s = max(
             0.0,
             float(
@@ -413,6 +430,11 @@ class KissModemWrapper(LoRaRadio):
         self._tx_inflight_lock = threading.Lock()
         self._tx_done_event = threading.Event()
         self._tx_done_result: Optional[bool] = None
+        # TX_BUSY seen while the current frame was in flight. Recorded for the log line
+        # and stats only -- see HW_ERR_TX_BUSY for why it cannot decide the send.
+        self._tx_busy_seen = False
+        # Why the last DATA send returned False, for the caller's error message.
+        self._tx_last_verdict: Optional[str] = None
 
         # Pending RX data payloads (Data frame) awaiting their RxMeta frame.
         # Each entry is (payload, deadline_monotonic); a frame is dispatched with
@@ -430,6 +452,7 @@ class KissModemWrapper(LoRaRadio):
             "rx_packets": 0,
             "tx_packets": 0,
             "errors": 0,
+            "tx_busy": 0,
             "last_rssi": -999,
             "last_snr": -999.0,
             "noise_floor": None,
@@ -488,6 +511,7 @@ class KissModemWrapper(LoRaRadio):
             self._reconnecting_event.clear()
             self._degraded = False
             self._degraded_reason = None
+            self._remember_modem_identity()
             return True
 
     def disconnect(self):
@@ -557,11 +581,150 @@ class KissModemWrapper(LoRaRadio):
                 logger.warning("RX worker did not survive startup on %s", self.port)
                 return False
 
+            self._remember_port_identity()
+            self._open_failure_key = None
+            self._open_failure_count = 0
             return True
         except Exception as e:
-            logger.error("Failed to connect to %s: %s", self.port, e)
+            self._note_open_failure(e)
             self.is_connected = False
             return False
+
+    # Consecutive identical open failures before the port is called wedged, and how
+    # often that line may repeat afterwards.
+    _WEDGED_PORT_FAILURES = 5
+    _WEDGED_PORT_LOG_INTERVAL_S = 60.0
+
+    def _port_identity(self, device: str) -> Optional[tuple]:
+        """Return (vid, pid, serial_number) for *device*, or None if unavailable.
+
+        Matches on the resolved path, not the configured string: a port is often
+        given as an alias (/dev/serial/by-id/..., or a udev-named /dev/openhop-modem
+        -- the constructor already treats the former specially) which never appears
+        verbatim in comports(), and a literal comparison would leave exactly those
+        setups with no identity to recover by.
+        """
+        target = os.path.realpath(device)
+        try:
+            from serial.tools import list_ports
+
+            for info in list_ports.comports():
+                if info.device == device or os.path.realpath(info.device) == target:
+                    return (info.vid, info.pid, info.serial_number)
+        except Exception as e:
+            logger.debug("Could not enumerate serial ports: %s", e)
+        return None
+
+    def _remember_port_identity(self) -> None:
+        """Record the open port's USB identity, if the OS exposes one."""
+        identity = self._port_identity(self.port)
+        if identity is not None and identity[0] is not None:
+            self._port_identity_ref = identity
+
+    def _alternate_port_paths(self) -> list[str]:
+        """Device paths other than the configured one carrying the same USB identity.
+
+        Node names are not stable across a re-enumeration -- this very modem moved
+        from cu.usbmodem1101 to cu.usbmodem12301 across a replug -- so a reconnect
+        loop pinned to the configured path can retry a name that will never open
+        again. Matching on vid/pid/serial is what keeps this from adopting some
+        other radio that happens to be plugged in.
+        """
+        reference = self._port_identity_ref
+        if not reference:
+            return []
+        try:
+            from serial.tools import list_ports
+
+            ports = list_ports.comports()
+        except Exception as e:
+            logger.debug("Could not enumerate serial ports: %s", e)
+            return []
+        current = os.path.realpath(self.port)
+        candidates = [
+            info.device
+            for info in ports
+            if os.path.realpath(info.device) != current
+            and (info.vid, info.pid, info.serial_number) == reference
+        ]
+        if reference[2] is None and len(candidates) > 1:
+            # Same vendor, same model, no serial number to tell them apart: two of
+            # these plugged in at once makes any pick a coin toss, and adopting the
+            # wrong radio is worse than staying degraded until the node comes back.
+            logger.warning(
+                "%d ports share this modem's USB identity and none report a serial "
+                "number; not guessing which one is the modem",
+                len(candidates),
+            )
+            return []
+        return candidates
+
+    def _remember_modem_identity(self) -> None:
+        """Record the handshaked modem's public key as the identity to expect."""
+        if self.modem_identity is not None:
+            self._modem_identity_ref = bytes(self.modem_identity)
+
+    def _modem_identity_matches(self) -> bool:
+        """True when the modem just handshaked is the one we were talking to.
+
+        The USB identity only says "same make and model"; a CP2102's serial is
+        often a batch constant like "0001". This compares the radio's own public
+        key, which is what actually distinguishes two modems. Unknown on either
+        side (no handshake info) means there is nothing to contradict, so the USB
+        identity stands as the only filter.
+        """
+        expected = self._modem_identity_ref
+        actual = self.modem_identity
+        if expected is None or actual is None:
+            return True
+        return bytes(actual) == bytes(expected)
+
+    def _note_open_failure(self, exc: BaseException) -> None:
+        """Log an open failure, escalating once the port stops opening at all.
+
+        A port that answers with the same error on every attempt is not coming back
+        by itself. Whether the node is gone (a rename, which _alternate_port_paths
+        covers) or present but unconfigurable (a wedged USB bridge, which nothing
+        here can clear) the operator needs telling once -- not an identical line
+        every retry for the life of the process.
+        """
+        errno_val = getattr(exc, "errno", None)
+        if errno_val is None and exc.args and isinstance(exc.args[0], int):
+            errno_val = exc.args[0]  # termios.error carries (errno, message)
+        key = (self.port, errno_val)
+        if key == self._open_failure_key:
+            self._open_failure_count += 1
+        else:
+            self._open_failure_key = key
+            self._open_failure_count = 1
+            self._open_failure_log_ts = None
+        self._degraded_reason = f"cannot open {self.port}: {exc}"
+
+        if self._open_failure_count < self._WEDGED_PORT_FAILURES:
+            logger.error("Failed to connect to %s: %s", self.port, exc)
+            return
+        now = time.monotonic()
+        if (
+            self._open_failure_log_ts is not None
+            and now - self._open_failure_log_ts < self._WEDGED_PORT_LOG_INTERVAL_S
+        ):
+            return
+        self._open_failure_log_ts = now
+        if os.path.exists(self.port):
+            detail = (
+                "the device is still enumerated but will not configure, so its USB "
+                "bridge or driver is wedged and retrying cannot clear it"
+            )
+        else:
+            detail = "the device node is gone and no port with a matching USB identity was found"
+        logger.error(
+            "%s has failed to open %d times with the same error (%s): %s. "
+            "Reconnect the modem physically to recover.",
+            self.port,
+            self._open_failure_count,
+            exc,
+            detail,
+        )
 
     def _run_post_connect_handshake(self) -> bool:
         """Run modem setup steps after serial open."""
@@ -832,18 +995,46 @@ class KissModemWrapper(LoRaRadio):
                 if self.stop_event.is_set():
                     break
                 self.is_connected = False
-                self._stop_io_threads(join_timeout=0.5)
-                if not self._open_serial_and_start_threads():
-                    continue
-                if not self._run_post_connect_handshake():
-                    self._close_serial_connection()
-                    self.is_connected = False
-                    continue
-                self.is_connected = True
-                self._degraded = False
-                self._degraded_reason = None
-                logger.info("KISS modem serial reconnect successful on attempt %s", attempts)
-                return
+                configured_port = self.port
+                # The configured path first; then any node carrying the same USB
+                # identity, so a device that came back renamed is still found.
+                for candidate in [configured_port] + self._alternate_port_paths():
+                    self._stop_io_threads(join_timeout=0.5)
+                    self.port = candidate
+                    if not self._open_serial_and_start_threads():
+                        continue
+                    if not self._run_post_connect_handshake():
+                        self._close_serial_connection()
+                        self.is_connected = False
+                        continue
+                    if candidate != configured_port and not self._modem_identity_matches():
+                        # Same make and model, different radio: adopting it would
+                        # silently transmit this node's traffic from someone else's
+                        # modem. Leave it alone and keep looking.
+                        logger.warning(
+                            "%s shares the USB identity but reports modem %s, not %s; "
+                            "not adopting it",
+                            candidate,
+                            (self.modem_identity or b"").hex()[:16] or "unknown",
+                            (self._modem_identity_ref or b"").hex()[:16] or "unknown",
+                        )
+                        self._close_serial_connection()
+                        self.is_connected = False
+                        continue
+                    self.is_connected = True
+                    self._degraded = False
+                    self._degraded_reason = None
+                    self._remember_modem_identity()
+                    if candidate != configured_port:
+                        logger.warning(
+                            "KISS modem reappeared as %s (was %s, same USB identity); "
+                            "continuing on the new path",
+                            candidate,
+                            configured_port,
+                        )
+                    logger.info("KISS modem serial reconnect successful on attempt %s", attempts)
+                    return
+                self.port = configured_port
 
     def _set_kiss_tx_delay(self, delay_ms: int) -> None:
         """
@@ -1083,7 +1274,13 @@ class KissModemWrapper(LoRaRadio):
             logger.error(f"Failed to send frame: {e}")
             return False
 
-    def send_frame_and_wait(self, data: bytes, timeout: float = RESPONSE_TIMEOUT) -> bool:
+    def send_frame_and_wait(
+        self,
+        data: bytes,
+        timeout: float = RESPONSE_TIMEOUT,
+        *,
+        verdict: Optional[list] = None,
+    ) -> bool:
         """
         Send a data frame and wait for the modem's TX_DONE.
 
@@ -1098,15 +1295,44 @@ class KissModemWrapper(LoRaRadio):
                 the estimated airtime of long frames.
 
         Returns:
-            True if transmission completed (TX_DONE ok), False otherwise.
+            True only when the modem confirms the transmit with TX_DONE status 0x01.
+            On False, the reason is appended to *verdict* when one is supplied, and
+            also left in ``_tx_last_verdict``.
+
+        Args:
+            verdict: optional one-element sink for this call's failure reason.
+                ``_tx_last_verdict`` is shared: senders serialise only inside
+                ``_tx_inflight_lock``, so by the time a caller reads that field the
+                next send may already have replaced it. Pass a list to be given the
+                reason belonging to *this* call.
+        """
+        ok, reason = self._send_frame_and_wait_verdict(data, timeout)
+        if verdict is not None:
+            verdict.append(reason)
+        return ok
+
+    def _verdict(self, reason: str) -> tuple[bool, str]:
+        """Record *reason* as the latest failure and return it to this caller."""
+        self._tx_last_verdict = reason
+        return (False, reason)
+
+    def _send_frame_and_wait_verdict(
+        self, data: bytes, timeout: float = RESPONSE_TIMEOUT
+    ) -> tuple[bool, Optional[str]]:
+        """:meth:`send_frame_and_wait`, returning (ok, reason) to the calling send.
+
+        ``_tx_last_verdict`` is shared state: senders serialise only inside
+        ``_tx_inflight_lock``, so by the time a caller reads the field its send has
+        released the lock and the next one may already have cleared it. The reason
+        travels back with the result instead.
         """
         if self._shutting_down:
-            return False
+            return self._verdict("shutting down")
 
         # Don't enqueue DATA while the link is down/reconnecting (mirror _send_command).
         in_reconnect_thread = threading.current_thread() is self.reconnect_thread
         if (self._reconnecting_event.is_set() or self._degraded) and not in_reconnect_thread:
-            return False
+            return self._verdict("serial link down or reconnecting")
 
         # Extend the wait to cover real airtime; a high-SF flood advert can exceed the
         # flat command timeout, which would otherwise look like a spurious TX_DONE timeout.
@@ -1119,29 +1345,56 @@ class KissModemWrapper(LoRaRadio):
         with self._tx_inflight_lock:
             self._tx_done_event.clear()
             self._tx_done_result = None
+            self._tx_busy_seen = False
+            self._tx_last_verdict = None
 
             if not self.send_frame(data):
-                return False
+                return self._verdict("frame not written to the modem")
 
             # Poll in short slices so a shutdown or mid-flight link failure returns
-            # promptly instead of stalling the full timeout. TX_DONE (success/fail)
-            # and TX_BUSY both set the event; a link drop sets it via
-            # _mark_serial_failure / cleanup.
+            # promptly instead of stalling the full timeout. TX_DONE (success or
+            # failure) sets the event; a link drop sets it via _mark_serial_failure /
+            # cleanup, leaving the result None. TX_BUSY deliberately does not set it.
             deadline = time.monotonic() + effective_timeout
             while not self._shutting_down:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
                 if self._tx_done_event.wait(min(0.1, remaining)):
-                    return self._tx_done_result or False
+                    return self._resolve_tx_done()
                 if self._degraded or self.stop_event.is_set():
-                    return False
+                    logger.warning("DATA send unconfirmed: serial link lost mid-transmit")
+                    return self._verdict("serial link lost mid-transmit")
 
             if self._shutting_down:
-                return False
+                return self._verdict("shutting down")
 
-            logger.warning("TX_DONE timeout")
-            return False
+            if self._tx_busy_seen:
+                # Either the modem discarded this frame (a transmit was already
+                # pending) or its host-bound queue overflowed and the TX_DONE never
+                # got back to us. Both leave the transmit unconfirmed; neither proves
+                # the frame stayed off the air.
+                reason = "TX_BUSY and no TX_DONE (modem busy, or host output queue full)"
+            else:
+                reason = f"no TX_DONE within {effective_timeout:.1f}s"
+            logger.warning("DATA send unconfirmed: %s", reason)
+            return self._verdict(reason)
+
+    def _resolve_tx_done(self) -> tuple[bool, Optional[str]]:
+        """Turn a set ``_tx_done_event`` into (ok, reason), recording the reason."""
+        result = self._tx_done_result
+        if result is True:
+            return (True, None)
+        if result is False:
+            # The modem completed a transmit cycle and reported failure. Its TX_SENDING
+            # watchdog reports 0x00 when the radio's TX-done interrupt is missed, so the
+            # frame may well have gone out -- but only 0x01 confirms a clean send, and
+            # nothing else here can tell the two apart.
+            reason = "modem reported TX_DONE status=0x00"
+        else:
+            reason = "transmit aborted (link lost or shutting down)"
+        logger.warning("DATA send failed: %s", reason)
+        return self._verdict(reason)
 
     def _send_command(
         self, sub_cmd: int, data: bytes = b"", timeout: float = RESPONSE_TIMEOUT
@@ -1606,6 +1859,22 @@ class KissModemWrapper(LoRaRadio):
         if not success:
             raise Exception("Failed to initialize KISS modem")
 
+    @property
+    def is_degraded(self) -> bool:
+        """True while the serial link is known-bad and the reconnect loop owns it.
+
+        ``is_connected`` on its own cannot be read as "usable": it is also False for
+        the moments between opening the port and finishing the handshake. A caller
+        deciding whether to wait rather than fail -- a local transmit weighing
+        whether its retry has any chance -- wants this instead.
+        """
+        return self._degraded
+
+    @property
+    def degraded_reason(self) -> Optional[str]:
+        """Why the link was last marked degraded, or None while it is healthy."""
+        return self._degraded_reason
+
     def check_radio_health(self) -> bool:
         """Check modem connectivity. Returns True if connected and modem responds to ping."""
         if not self.is_connected:
@@ -1691,9 +1960,16 @@ class KissModemWrapper(LoRaRadio):
 
         # Wait for modem-level TX_DONE instead of treating queueing as success.
         # Run the blocking wait off the event loop.
-        success = await asyncio.to_thread(self.send_frame_and_wait, data, RESPONSE_TIMEOUT)
+        # Dispatch through the public method (subclasses and tests override it),
+        # collecting this send's own reason rather than reading shared state after
+        # the in-flight lock has been handed to the next sender.
+        verdict: list = []
+        success = await asyncio.to_thread(
+            self.send_frame_and_wait, data, RESPONSE_TIMEOUT, verdict=verdict
+        )
         if not success:
-            raise Exception("Failed to send frame via KISS modem (no TX_DONE)")
+            reason = (verdict[0] if verdict else None) or self._tx_last_verdict or "no TX_DONE"
+            raise Exception(f"Failed to send frame via KISS modem: {reason}")
 
         # Use short timeout for GET_AIRTIME so TX path is not blocked if modem
         # is busy or unresponsive (avoids 5s stall and subsequent bad state).
@@ -2101,13 +2377,15 @@ class KissModemWrapper(LoRaRadio):
                     self.stats["errors"] += 1
                     logger.warning(f"Modem error: 0x{err_code:02X}")
                 if err_code == HW_ERR_TX_BUSY:
-                    # TX_BUSY is a DATA-transmit rejection, not a SetHardware response.
-                    # Wake the in-flight DATA sender so it fails fast (and can retry)
-                    # rather than stalling until the TX_DONE timeout, and keep it out
-                    # of the SetHardware response path (where it would be mis-consumed
-                    # as the in-flight command's error reply).
-                    self._tx_done_result = False
-                    self._tx_done_event.set()
+                    # Not a verdict on the in-flight DATA frame: the same code covers a
+                    # host-output-queue overflow, which says nothing about our transmit
+                    # (see HW_ERR_TX_BUSY). Record it and let TX_DONE decide -- failing
+                    # the send here reported failure for frames that went out fine
+                    # whenever inbound traffic backed the modem's queue up. It still
+                    # must not reach the SetHardware response path, where it would be
+                    # mis-consumed as the in-flight command's error reply.
+                    self.stats["tx_busy"] += 1
+                    self._tx_busy_seen = True
                 else:
                     with self._response_lock:
                         expected = self._expected_response_subcmds

--- a/tests/test_kiss_modem_wrapper.py
+++ b/tests/test_kiss_modem_wrapper.py
@@ -755,7 +755,9 @@ class TestCommandResponses:
         assert result is not None
         assert result["airtime_ms"] == 42
         assert to_thread_mock.await_count == 2
-        to_thread_mock.assert_any_await(modem.send_frame_and_wait, b"payload", RESPONSE_TIMEOUT)
+        to_thread_mock.assert_any_await(
+            modem.send_frame_and_wait, b"payload", RESPONSE_TIMEOUT, verdict=[]
+        )
         to_thread_mock.assert_any_await(modem.get_airtime, len(b"payload"), 1.0)
 
 
@@ -2117,9 +2119,12 @@ class TestSerialRecovery:
 
         modem.configure_radio = MagicMock(side_effect=transient_configure_failure)
 
-        with patch(
-            "openhop_core.hardware.kiss_modem_wrapper.time.sleep", return_value=None
-        ) as sleep_mock, patch("threading.Event.wait", return_value=None):
+        with (
+            patch(
+                "openhop_core.hardware.kiss_modem_wrapper.time.sleep", return_value=None
+            ) as sleep_mock,
+            patch("threading.Event.wait", return_value=None),
+        ):
             assert modem.connect() is True
 
         assert modem.configure_radio.call_count == 2
@@ -2140,8 +2145,9 @@ class TestSerialRecovery:
         modem._set_kiss_tx_delay = MagicMock()
         modem.configure_radio = MagicMock(return_value=False)
 
-        with patch("openhop_core.hardware.kiss_modem_wrapper.time.sleep", return_value=None), patch(
-            "threading.Event.wait", return_value=None
+        with (
+            patch("openhop_core.hardware.kiss_modem_wrapper.time.sleep", return_value=None),
+            patch("threading.Event.wait", return_value=None),
         ):
             assert modem.connect() is False
 
@@ -2199,7 +2205,7 @@ class TestSerialRecovery:
 
 
 class TestKissDataTxSingleFlight:
-    """DATA transmits are single-flight and fail fast on TX_BUSY / link loss."""
+    """DATA transmits are single-flight; only TX_DONE decides the outcome."""
 
     def test_send_frame_and_wait_is_single_flight(self):
         """A second DATA frame must not be written while the first is in flight."""
@@ -2249,17 +2255,20 @@ class TestKissDataTxSingleFlight:
         assert results.get("b") is True
         assert order == ["A", "B"]
 
-    def test_tx_busy_wakes_sender_and_is_not_queued(self):
-        """A 0x07 (TX_BUSY) error fails the sender fast and is not mis-routed to the
-        SetHardware response path."""
+    def test_tx_busy_does_not_fail_a_transmit_the_modem_confirms(self):
+        """A TX_DONE arriving behind a TX_BUSY still confirms the send.
+
+        Firmware emits the same 0x07 when its 2-slot host-output queue overflows -- a
+        receive-side condition. Failing the send on it reported failure for frames that
+        went out fine whenever inbound traffic backed the modem up.
+        """
         modem = KissModemWrapper(port="/dev/null", auto_configure=False)
         modem.is_connected = True
 
         sent = threading.Event()
-        modem.send_frame = lambda data: (sent.set() or True)
+        modem.send_frame = lambda data: sent.set() or True
 
         result: dict[str, object] = {}
-        start = time.monotonic()
         t = threading.Thread(
             target=lambda: result.__setitem__("r", modem.send_frame_and_wait(b"AA", timeout=5.0))
         )
@@ -2270,10 +2279,64 @@ class TestKissDataTxSingleFlight:
         for byte in err:
             modem._decode_kiss_byte(byte)
 
+        time.sleep(0.15)  # outlast a poll slice: TX_BUSY must not end the wait
+        assert not result
+
+        tx_done = bytes([KISS_FEND, KISS_CMD_SETHARDWARE, RESP_TX_DONE, 0x01, KISS_FEND])
+        for byte in tx_done:
+            modem._decode_kiss_byte(byte)
+
+        t.join(timeout=1.0)
+        assert result.get("r") is True
+        assert modem.stats["tx_busy"] == 1  # counted, so backpressure stays visible
+        assert len(modem._response_queue) == 0  # not consumed by the SetHardware waiter
+
+    def test_tx_busy_without_tx_done_leaves_the_send_unconfirmed(self):
+        """With no TX_DONE behind it, TX_BUSY still fails the send -- and says why."""
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        modem.is_connected = True
+
+        sent = threading.Event()
+        modem.send_frame = lambda data: sent.set() or True
+
+        result: dict[str, object] = {}
+        t = threading.Thread(
+            target=lambda: result.__setitem__("r", modem.send_frame_and_wait(b"AA", timeout=0.2))
+        )
+        t.start()
+        assert sent.wait(timeout=1.0)
+
+        err = bytes([KISS_FEND, KISS_CMD_SETHARDWARE, RESP_ERROR, HW_ERR_TX_BUSY, KISS_FEND])
+        for byte in err:
+            modem._decode_kiss_byte(byte)
+
+        t.join(timeout=5.0)
+        assert result.get("r") is False
+        assert "TX_BUSY" in (modem._tx_last_verdict or "")
+        assert len(modem._response_queue) == 0
+
+    def test_tx_done_failure_status_is_reported_as_the_modems_verdict(self):
+        """A TX_DONE carrying 0x00 fails the send, named as the modem's own status."""
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        modem.is_connected = True
+
+        sent = threading.Event()
+        modem.send_frame = lambda data: sent.set() or True
+
+        result: dict[str, object] = {}
+        t = threading.Thread(
+            target=lambda: result.__setitem__("r", modem.send_frame_and_wait(b"AA", timeout=5.0))
+        )
+        t.start()
+        assert sent.wait(timeout=1.0)
+
+        tx_fail = bytes([KISS_FEND, KISS_CMD_SETHARDWARE, RESP_TX_DONE, 0x00, KISS_FEND])
+        for byte in tx_fail:
+            modem._decode_kiss_byte(byte)
+
         t.join(timeout=1.0)
         assert result.get("r") is False
-        assert time.monotonic() - start < 2.0  # failed fast, not via the 5s timeout
-        assert len(modem._response_queue) == 0  # not consumed by the SetHardware waiter
+        assert "status=0x00" in (modem._tx_last_verdict or "")
 
     def test_serial_failure_wakes_in_flight_sender(self):
         """A serial failure mid-transmit wakes the waiter instead of stalling."""
@@ -2282,7 +2345,7 @@ class TestKissDataTxSingleFlight:
         modem._start_reconnect_worker = MagicMock()  # don't spawn a reconnect thread
 
         sent = threading.Event()
-        modem.send_frame = lambda data: (sent.set() or True)
+        modem.send_frame = lambda data: sent.set() or True
 
         result: dict[str, object] = {}
         start = time.monotonic()
@@ -2533,9 +2596,10 @@ class TestReconnectRequiresLiveReader:
             modem.rx_thread.join(timeout=2.0)
             return True
 
-        with patch(
-            "openhop_core.hardware.kiss_modem_wrapper.serial.Serial", return_value=fake
-        ), patch.object(modem, "_wait_for_modem_ready", side_effect=_ready):
+        with (
+            patch("openhop_core.hardware.kiss_modem_wrapper.serial.Serial", return_value=fake),
+            patch.object(modem, "_wait_for_modem_ready", side_effect=_ready),
+        ):
             assert modem._open_serial_and_start_threads() is False
 
     def test_open_reports_success_when_the_reader_survives(self):
@@ -2557,9 +2621,10 @@ class TestReconnectRequiresLiveReader:
 
         fake = QuietSerial()
         try:
-            with patch(
-                "openhop_core.hardware.kiss_modem_wrapper.serial.Serial", return_value=fake
-            ), patch.object(modem, "_wait_for_modem_ready", return_value=True):
+            with (
+                patch("openhop_core.hardware.kiss_modem_wrapper.serial.Serial", return_value=fake),
+                patch.object(modem, "_wait_for_modem_ready", return_value=True),
+            ):
                 assert modem._open_serial_and_start_threads() is True
                 assert modem.rx_thread.is_alive()
         finally:
@@ -2663,16 +2728,12 @@ class TestSerialPortOpen:
         """Run connect() against a fake pyserial, return the Serial() kwargs."""
         modem = KissModemWrapper(port="/dev/null", auto_configure=False)
         modem._post_connect_settle_s = 0
-        with patch(
-            "openhop_core.hardware.kiss_modem_wrapper.serial"
-        ) as fake_serial, patch.object(
-            kiss_modem_wrapper.threading, "Thread"
-        ), patch.object(
-            KissModemWrapper, "_wait_for_modem_ready", return_value=True
-        ), patch.object(
-            KissModemWrapper, "_query_modem_info"
-        ), patch.object(
-            KissModemWrapper, "_set_kiss_tx_delay"
+        with (
+            patch("openhop_core.hardware.kiss_modem_wrapper.serial") as fake_serial,
+            patch.object(kiss_modem_wrapper.threading, "Thread"),
+            patch.object(KissModemWrapper, "_wait_for_modem_ready", return_value=True),
+            patch.object(KissModemWrapper, "_query_modem_info"),
+            patch.object(KissModemWrapper, "_set_kiss_tx_delay"),
         ):
             modem.connect()
         assert fake_serial.Serial.call_count == 1
@@ -2685,3 +2746,201 @@ class TestSerialPortOpen:
     def test_connect_does_not_enable_hardware_flow_control(self):
         """The firmware implements no RTS/CTS flow control on the RX pipe."""
         assert self._connect_with_fake_serial().get("rtscts") is False
+
+
+class TestKissPortRecovery:
+    """Reconnect follows a renamed node, and says when a port is not coming back."""
+
+    def test_reconnect_follows_a_renamed_node(self):
+        """A device that re-enumerates under a new name is still reconnected to.
+
+        macOS renamed this very modem from cu.usbmodem1101 to cu.usbmodem12301
+        across a replug; pinned to the old path, the loop would retry forever.
+        """
+        modem = KissModemWrapper(port="/dev/old-node", auto_configure=False)
+        modem._stop_io_threads = MagicMock()
+        modem._alternate_port_paths = lambda: ["/dev/new-node"]
+        # Only the new path opens; the configured one is gone.
+        modem._open_serial_and_start_threads = lambda: modem.port == "/dev/new-node"
+        modem._run_post_connect_handshake = MagicMock(return_value=True)
+
+        with patch.object(kiss_modem_wrapper.time, "sleep", return_value=None):
+            modem._reconnect_loop()
+
+        assert modem.port == "/dev/new-node"
+        assert modem.is_connected is True
+        assert modem._degraded is False
+
+    def test_reconnect_keeps_the_configured_path_when_nothing_opens(self):
+        """A failed sweep must not leave the wrapper pointed at a candidate."""
+        modem = KissModemWrapper(port="/dev/old-node", auto_configure=False)
+        modem._stop_io_threads = MagicMock()
+        modem._alternate_port_paths = lambda: ["/dev/new-node"]
+        modem._open_serial_and_start_threads = lambda: False
+        modem._reconnect_max_attempts = 2
+
+        with patch.object(kiss_modem_wrapper.time, "sleep", return_value=None):
+            modem._reconnect_loop()
+
+        assert modem.port == "/dev/old-node"
+        assert modem.is_connected is False
+
+    def test_alternate_paths_match_on_usb_identity(self):
+        """Only a port with the same vid/pid/serial is a candidate."""
+        modem = KissModemWrapper(port="/dev/old-node", auto_configure=False)
+        modem._port_identity_ref = (0x10C4, 0xEA60, "0001")
+
+        same = MagicMock(device="/dev/new-node", vid=0x10C4, pid=0xEA60, serial_number="0001")
+        other = MagicMock(device="/dev/other-radio", vid=0x239A, pid=0x8029, serial_number="ZZ")
+        fake_list_ports = MagicMock(comports=MagicMock(return_value=[same, other]))
+        with (
+            patch.dict("sys.modules", {"serial.tools.list_ports": fake_list_ports}),
+            patch("serial.tools.list_ports", fake_list_ports, create=True),
+        ):
+            assert modem._alternate_port_paths() == ["/dev/new-node"]
+
+    def test_alternate_paths_needs_a_known_identity(self):
+        """With no recorded identity, never adopt some other serial port."""
+        modem = KissModemWrapper(port="/dev/old-node", auto_configure=False)
+        assert modem._port_identity_ref is None
+        assert modem._alternate_port_paths() == []
+
+    def test_repeated_identical_open_failure_escalates_once(self, caplog):
+        """The same errno every attempt gets one actionable line, not one per retry."""
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        err = OSError(22, "Invalid argument")
+
+        with caplog.at_level("ERROR"):
+            for _ in range(modem._WEDGED_PORT_FAILURES + 3):
+                modem._note_open_failure(err)
+
+        wedged = [r for r in caplog.records if "failed to open" in r.getMessage()]
+        assert len(wedged) == 1  # escalated once, then rate-limited
+        assert "wedged" in wedged[0].getMessage()  # /dev/null exists, so: not a rename
+        assert modem._degraded_reason is not None
+        assert "Invalid argument" in modem._degraded_reason
+
+    def test_a_different_error_restarts_the_count(self):
+        """A changing failure is still churn, not a stuck port."""
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        modem._note_open_failure(OSError(22, "Invalid argument"))
+        modem._note_open_failure(OSError(22, "Invalid argument"))
+        assert modem._open_failure_count == 2
+        modem._note_open_failure(OSError(2, "No such file or directory"))
+        assert modem._open_failure_count == 1
+
+
+def _port_info(device, vid=0x10C4, pid=0xEA60, serial_number="0001"):
+    """Stand-in for a pyserial ListPortInfo entry."""
+    return MagicMock(device=device, vid=vid, pid=pid, serial_number=serial_number)
+
+
+class TestKissPortIdentityEdges:
+    """Identity matching must not guess, and must cope with aliased device paths."""
+
+    def test_serial_less_twins_are_not_guessed_between(self):
+        """Two of the same model with no serial number: any pick would be a coin toss."""
+        modem = KissModemWrapper(port="/dev/old-node", auto_configure=False)
+        modem._port_identity_ref = (0x10C4, 0xEA60, None)
+
+        ports = [
+            _port_info("/dev/twin-a", serial_number=None),
+            _port_info("/dev/twin-b", serial_number=None),
+        ]
+        with patch("serial.tools.list_ports.comports", return_value=ports):
+            assert modem._alternate_port_paths() == []
+
+    def test_a_lone_serial_less_candidate_is_still_followed(self):
+        """The no-serial guard must not disable recovery when there is no ambiguity."""
+        modem = KissModemWrapper(port="/dev/old-node", auto_configure=False)
+        modem._port_identity_ref = (0x10C4, 0xEA60, None)
+
+        ports = [_port_info("/dev/new-node", serial_number=None)]
+        with patch("serial.tools.list_ports.comports", return_value=ports):
+            assert modem._alternate_port_paths() == ["/dev/new-node"]
+
+    def test_identity_is_learned_through_an_aliased_path(self, tmp_path):
+        """A by-id symlink never appears verbatim in comports(); resolve it."""
+        alias = tmp_path / "openhop-modem"
+        alias.symlink_to("/dev/null")
+        modem = KissModemWrapper(port=str(alias), auto_configure=False)
+
+        with patch("serial.tools.list_ports.comports", return_value=[_port_info("/dev/null")]):
+            modem._remember_port_identity()
+
+        assert modem._port_identity_ref == (0x10C4, 0xEA60, "0001")
+
+    def test_an_alias_is_not_offered_as_its_own_alternate(self, tmp_path):
+        """The configured alias and its target are one device, not two."""
+        alias = tmp_path / "openhop-modem"
+        alias.symlink_to("/dev/null")
+        modem = KissModemWrapper(port=str(alias), auto_configure=False)
+        modem._port_identity_ref = (0x10C4, 0xEA60, "0001")
+
+        with patch("serial.tools.list_ports.comports", return_value=[_port_info("/dev/null")]):
+            assert modem._alternate_port_paths() == []
+
+    def test_a_different_radio_on_a_matching_path_is_refused(self):
+        """Same make and model is not the same radio; the modem's own key decides."""
+        modem = KissModemWrapper(port="/dev/old-node", auto_configure=False)
+        modem._stop_io_threads = MagicMock()
+        modem._alternate_port_paths = lambda: ["/dev/new-node"]
+        modem._open_serial_and_start_threads = lambda: modem.port == "/dev/new-node"
+        modem._modem_identity_ref = b"\x01" * 32
+        modem._reconnect_max_attempts = 1
+
+        def handshake():
+            modem.modem_identity = b"\x02" * 32  # somebody else's modem
+            return True
+
+        modem._run_post_connect_handshake = handshake
+        modem._close_serial_connection = MagicMock()
+
+        with patch.object(kiss_modem_wrapper.time, "sleep", return_value=None):
+            modem._reconnect_loop()
+
+        assert modem.is_connected is False
+        assert modem.port == "/dev/old-node"  # not adopted
+
+    def test_wedged_port_escalates_within_a_minute_of_boot(self, caplog):
+        """A low monotonic clock must not swallow the first escalation."""
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        err = OSError(22, "Invalid argument")
+
+        with patch.object(kiss_modem_wrapper.time, "monotonic", return_value=5.0):
+            with caplog.at_level("ERROR"):
+                for _ in range(modem._WEDGED_PORT_FAILURES):
+                    modem._note_open_failure(err)
+
+        assert any("failed to open" in r.getMessage() for r in caplog.records)
+
+
+class TestKissSendVerdictOwnership:
+    """A send's failure reason must belong to that send, not to whoever ran last."""
+
+    def test_verdict_sink_carries_this_calls_reason(self):
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        modem.is_connected = True
+        modem.send_frame = lambda data: True
+
+        sink: list = []
+        assert modem.send_frame_and_wait(b"AA", timeout=0.2, verdict=sink) is False
+        assert sink and "no TX_DONE" in sink[0]
+
+    @pytest.mark.asyncio
+    async def test_send_raises_with_its_own_reason_not_the_shared_field(self):
+        """The shared field can be replaced by a concurrent send; the sink cannot."""
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        modem.is_connected = True
+        modem.lbt_enabled = False
+
+        def fake_send(data, timeout=None, *, verdict=None):
+            if verdict is not None:
+                verdict.append("mine: TX_DONE status=0x00")
+            modem._tx_last_verdict = "theirs: some other send"
+            return False
+
+        modem.send_frame_and_wait = fake_send
+
+        with pytest.raises(Exception, match="mine: TX_DONE status=0x00"):
+            await modem.send(b"\x01\x02\x03\x04")


### PR DESCRIPTION
Firmware overloaded TX_BUSY (0x07) when it moved its host-bound writes to a 2-slot queue: the code now means "radio TX busy, or host output queue full", and onPacketReceived raises it while queueing an inbound DATA frame. So an RX packet the modem could not hand over failed whatever transmit happened to be in flight -- reported to the companion client as ERR_CODE_NOT_FOUND while the packet was already on the air. TX_BUSY is now counted (stats["tx_busy"]) and left to TX_DONE, which firmware retains until it can be queued rather than dropping.

Every failure also names itself: _resolve_tx_done separates a modem that reported status=0x00 from a link lost mid-transmit, and the reason travels back through a per-call verdict sink rather than a field the next sender can overwrite, so send() raises with the reason belonging to its own send.

Reconnect now follows a device that comes back under a new node name -- macOS renamed one modem from cu.usbmodem1101 to cu.usbmodem12301 across a replug, a path the loop could never open again. Candidates are filtered by USB vid/pid/serial resolved through symlinks (a /dev/serial/by-id path never appears verbatim in comports()), ambiguous serial-less twins are refused rather than guessed between, and an adopted path must report the same modem public key before it is kept.

A port that fails to open with the same errno five times says so once -- naming whether the node is present but unconfigurable or gone -- then rate-limits, instead of repeating one line every retry for the life of the process.