### PR TITLE
fix(dispatcher): preserve radio ingress across asynchronous processing

### DIFF
--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -36,6 +36,9 @@ from .handlers import (
 
 ACK_TIMEOUT = 5.0  # seconds to wait for an ACK
 
+# Distinguish direct processing from a callback that captured an unknown ingress.
+_RX_RADIO_ID_UNSET = object()
+
 # Flood reception-quality delay bounds (MeshCore Dispatcher::checkRecv):
 # delays under the threshold process immediately, longer ones are capped.
 MIN_RX_DELAY_MS = 50.0
@@ -493,11 +496,25 @@ class Dispatcher:
         """Called by the radio when a packet comes in. rssi/snr are per-packet when provided."""
         if not self._rx_enabled:
             return
+        # The fabric's legacy callback is synchronous: capture before scheduling,
+        # while last_rx_radio_id still describes this reception.
+        rx_radio_id = self._get_rx_radio_id()
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(self._process_received_packet(data, rssi, snr))
+            loop.create_task(
+                self._process_received_packet(data, rssi, snr, rx_radio_id=rx_radio_id)
+            )
         except RuntimeError:
             self._log("No event loop running, cannot process received packet")
+
+    def _get_rx_radio_id(self) -> Optional[str]:
+        """Read the current ingress from a radio or its fabric adapter."""
+        rx_radio_id = getattr(self.radio, "last_rx_radio_id", None)
+        if rx_radio_id is None:
+            fabric = getattr(self.radio, "fabric", None)
+            if fabric is not None:
+                rx_radio_id = getattr(fabric, "last_rx_radio_id", None)
+        return rx_radio_id
 
     def calc_rx_delay(self, score: float, air_time_ms: float) -> float:
         """Reception-quality delay in ms before a flood packet is processed.
@@ -541,8 +558,14 @@ class Dispatcher:
         data: bytes,
         rssi: Optional[int] = None,
         snr: Optional[float] = None,
+        *,
+        rx_radio_id: Any = _RX_RADIO_ID_UNSET,
     ) -> None:
         """Process received packet. rssi/snr are per-packet when provided."""
+        # Direct callers retain the legacy lookup, but snapshot before any await.
+        # An explicitly captured None must not pick up a later reception's id.
+        if rx_radio_id is _RX_RADIO_ID_UNSET:
+            rx_radio_id = self._get_rx_radio_id()
         # Notify raw RX subscribers so clients can track repeats
         if rssi is not None:
             rssi_val = rssi
@@ -582,11 +605,6 @@ class Dispatcher:
         pkt._rssi = rssi if rssi is not None else self.radio.get_last_rssi()
         pkt._snr = snr if snr is not None else self.radio.get_last_snr()
         # Multi-radio: stamp which fabric radio delivered this frame (if known).
-        rx_radio_id = getattr(self.radio, "last_rx_radio_id", None)
-        if rx_radio_id is None:
-            fabric = getattr(self.radio, "fabric", None)
-            if fabric is not None:
-                rx_radio_id = getattr(fabric, "last_rx_radio_id", None)
         if rx_radio_id is not None:
             pkt._rx_radio_id = rx_radio_id
 

--- a/tests/test_dispatcher_ingress.py
+++ b/tests/test_dispatcher_ingress.py
@@ -1,0 +1,120 @@
+"""Ingress identity must survive scheduling and asynchronous RX subscribers."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from openhop_core.node.dispatcher import Dispatcher
+from openhop_core.rf_fabric import FabricRadio
+from tests.test_rf_fabric_phase2 import _MockRadio, _advert_bytes
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pause_raw", [False, True])
+async def test_fabric_burst_preserves_ingress(pause_raw):
+    local, link = _MockRadio(), _MockRadio()
+    radio = FabricRadio(radios=[(local, "local"), (link, "link")])
+    dispatcher = Dispatcher(radio)
+    entered, release, complete = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    seen, raw = [], []
+    link_data, local_data = _advert_bytes(b"link"), _advert_bytes(b"local")
+
+    async def on_raw(data, rssi, snr):
+        raw.append((data, rssi, snr))
+        if pause_raw and data == link_data:
+            entered.set()
+            await release.wait()
+
+    def on_packet(pkt, data):
+        seen.append((data, pkt._rx_radio_id, pkt._rssi, pkt._snr))
+        if len(seen) == 2:
+            complete.set()
+
+    dispatcher.add_raw_rx_subscriber(on_raw)
+    dispatcher.packet_analysis_callback = on_packet
+    try:
+        link.inject(link_data, -80, 2.0)
+        if pause_raw:
+            await asyncio.wait_for(entered.wait(), 1)
+        local.inject(local_data, -60, 7.0)
+        release.set()
+        await asyncio.wait_for(complete.wait(), 1)
+        assert sorted(seen) == sorted([
+            (link_data, "link", -80, 2.0),
+            (local_data, "local", -60, 7.0),
+        ])
+        assert raw == [(link_data, -80, 2.0), (local_data, -60, 7.0)]
+    finally:
+        release.set()
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("nested_fabric", [False, True])
+async def test_direct_processing_snapshots_ingress_before_raw_subscriber(nested_fabric):
+    radio = _MockRadio()
+    source = SimpleNamespace(last_rx_radio_id="link") if nested_fabric else radio
+    source.last_rx_radio_id = "link"
+    if nested_fabric:
+        radio.fabric = source
+    dispatcher = Dispatcher(radio)
+    seen = []
+
+    async def on_raw(data, rssi, snr):
+        source.last_rx_radio_id = "local"
+        await asyncio.sleep(0)
+
+    dispatcher.add_raw_rx_subscriber(on_raw)
+    dispatcher.packet_analysis_callback = lambda pkt, data: seen.append(pkt._rx_radio_id)
+    try:
+        await dispatcher._process_received_packet(_advert_bytes(), -80, 2.0)
+        assert seen == ["link"]
+    finally:
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_unknown_ingress_is_not_replaced_after_scheduling():
+    radio = _MockRadio()
+    radio.last_rx_radio_id = None
+    dispatcher = Dispatcher(radio)
+    seen, complete = [], asyncio.Event()
+
+    def on_packet(pkt, data):
+        seen.append(getattr(pkt, "_rx_radio_id", None))
+        complete.set()
+
+    dispatcher.packet_analysis_callback = on_packet
+    try:
+        radio.inject(_advert_bytes())
+        radio.last_rx_radio_id = "later"
+        await asyncio.wait_for(complete.wait(), 1)
+        assert seen == [None]
+    finally:
+        await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wrapped", [False, True])
+@pytest.mark.parametrize("with_metrics", [False, True])
+async def test_single_radio_callback_compatibility(wrapped, with_metrics):
+    physical = _MockRadio()
+    radio = FabricRadio(radio=physical, radio_id="solo") if wrapped else physical
+    dispatcher = Dispatcher(radio)
+    seen, complete = [], asyncio.Event()
+
+    def on_packet(pkt, data):
+        seen.append((getattr(pkt, "_rx_radio_id", None), pkt._rssi, pkt._snr))
+        complete.set()
+
+    dispatcher.packet_analysis_callback = on_packet
+    try:
+        args = (-70, 3.0) if with_metrics else ()
+        physical.inject(_advert_bytes(), *args)
+        await asyncio.wait_for(complete.wait(), 1)
+        assert seen == [("solo" if wrapped else None,
+                         -70 if with_metrics else -80,
+                         3.0 if with_metrics else 7.5)]
+    finally:
+        await dispatcher.stop()


### PR DESCRIPTION
## Summary
Preserve the receiving-radio identity across asynchronous packet processing so multi-radio bursts cannot be attributed to the wrong interface.

## Problem
The dispatcher queued received packet bytes and signal measurements, then looked up the fabric's mutable `last_rx_radio_id` when processing the packet. Another radio could receive a packet before that task ran, or while a raw RX subscriber was awaiting, causing both packets to inherit the most recent radio identity.

Repeater uses this identity for ingress-specific policy and bridge-peer selection. The regression reproduction allowed a packet through a policy that should have dropped its actual ingress interface.

## Changes
- Capture ingress synchronously in the radio callback, before scheduling packet processing.
- Carry the captured identity through a keyword-only processing argument instead of consulting mutable fabric state later.
- Preserve direct processing callers by capturing their ingress at coroutine entry, before awaiting raw subscribers.
- Distinguish omitted context from explicitly captured unknown ingress (`None`) so later receptions cannot supply an identity retroactively.
- Preserve bytes-only and three-argument callback compatibility, single-radio behavior, and nested fabric lookup.

## Verification
- Full Core suite: **1,827 passed**.
- **9 regression/compatibility cases** cover back-to-back physical fake-radio callbacks, an awaiting raw RX subscriber, direct processing, unknown ingress, nested fabric lookup, and single-radio callback forms.
- Tests produced **5 expected attribution failures and 4 compatibility passes** before the fix; all 9 pass afterward.
- Cross-repository probe using Repeater's actual policy engine and bridge-peer resolver passed with fake radios.
- Applicable changed-file Black/isort/flake8 checks and `git diff --check`: passed.
- Installed-code ingress regressions also passed on the deployment host. The service successfully restarted with a two-radio fabric and both modem connections established.

## Scope and limitations
- No wire-format, public radio callback API, firmware, or dependency changes.
- No unrelated TCP/USB RSSI/SNR changes.
- This addresses the synchronous callback-to-async-processing race; it does not introduce general thread safety or redesign fabric callback dispatch.
- The deterministic burst/policy regressions use fake radios; this is not a claim of simultaneous over-the-air multi-radio validation.
