### PR TITLE
feat(sx1262): compensate reported RSSI for external front-end LNA gain

### DIFF
--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -87,6 +87,7 @@ class SX1262Radio(LoRaRadio):
         use_dio3_tcxo: bool = False,
         dio3_tcxo_voltage: float = 1.8,
         use_dio2_rf: bool = False,
+        lna_gain_db: float = 0.0,
         lbt_max_wait_seconds: float = 4.0,
         lbt_retry_interval_ms: int = 200,
         radio_timing_delay: float = RADIO_TIMING_DELAY,
@@ -159,6 +160,15 @@ class SX1262Radio(LoRaRadio):
         self.use_dio3_tcxo = use_dio3_tcxo
         self.dio3_tcxo_voltage = dio3_tcxo_voltage
         self.use_dio2_rf = use_dio2_rf
+
+        # Gain of any external front-end LNA sitting between the antenna and the
+        # SX1262. The chip cannot know it is there, so every RSSI it reports -
+        # received packets and the idle noise floor alike - is inflated by this
+        # much. Subtracting it refers those figures back to the antenna port so
+        # they can be compared against a bare SX1262. Defaults to 0.0, which
+        # leaves behaviour unchanged for boards without a front end.
+        # SNR is a ratio, so front-end gain cancels out: it is NOT adjusted.
+        self.lna_gain_db = float(lna_gain_db)
 
         # State variables
         self.lora: Optional[SX126x] = None
@@ -615,6 +625,8 @@ class SX1262Radio(LoRaRadio):
                                             snr_db,
                                             signal_rssi_dbm,
                                         ) = self.lora.getSignalMetrics()
+                                        packet_rssi_dbm -= self.lna_gain_db
+                                        signal_rssi_dbm -= self.lna_gain_db
                                         (
                                             payloadLengthRx,
                                             rxStartBufferPointer,
@@ -671,9 +683,9 @@ class SX1262Radio(LoRaRadio):
                                         snr_db,
                                         signal_rssi_dbm,
                                     ) = self.lora.getSignalMetrics()
-                                    self.last_rssi = int(packet_rssi_dbm)
+                                    self.last_rssi = int(packet_rssi_dbm - self.lna_gain_db)
                                     self.last_snr = snr_db
-                                    self.last_signal_rssi = int(signal_rssi_dbm)
+                                    self.last_signal_rssi = int(signal_rssi_dbm - self.lna_gain_db)
 
                                     logger.debug(
                                         "[RX] Packet received: length=%d, RSSI=%ddBm, SNR=%.1fdB",
@@ -1607,6 +1619,10 @@ class SX1262Radio(LoRaRadio):
                 logger.debug("[Noise] Sample rejected: out-of-range RSSI %.1f dBm", current_rssi)
                 return
 
+            # Range check above is against the chip's own scale; refer the
+            # accepted sample back to the antenna port before averaging.
+            current_rssi -= self.lna_gain_db
+
             self._noise_floor_samples.append(current_rssi)
             if len(self._noise_floor_samples) > self.NUM_NOISE_FLOOR_SAMPLES:
                 self._noise_floor_samples.pop(0)
@@ -1760,6 +1776,7 @@ class SX1262Radio(LoRaRadio):
             "last_rssi": self.last_rssi,
             "last_snr": self.last_snr,
             "last_signal_rssi": self.last_signal_rssi,
+            "lna_gain_db": self.lna_gain_db,
             "crc_error_count": self.crc_error_count,
         }
 

--- a/tests/test_lna_gain_offset.py
+++ b/tests/test_lna_gain_offset.py
@@ -1,0 +1,77 @@
+"""External front-end LNA gain compensation.
+
+Boards built around modules such as the Ebyte E22P, or front ends like the
+SKY66122, put an LNA between the antenna and the SX1262. The chip has no way to
+know it is there, so every RSSI it reports is inflated by that LNA's gain. These
+tests pin the compensation down: RSSI figures move, SNR does not, and a board
+that declares no front end behaves exactly as before.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from openhop_core.hardware.sx1262_wrapper import SX1262Radio
+
+# raw register 190 -> -(190/2) = -95.0 dBm measured at the chip
+RAW_RSSI_MINUS_95 = 190
+
+
+def _prime_for_noise_sample(radio: SX1262Radio, raw_rssi: int) -> SX1262Radio:
+    """Satisfy the idle-window guards so _sample_noise_floor() takes a sample."""
+    lora = MagicMock()
+    lora.getRssiInst.return_value = raw_rssi
+    lora.getIrqStatus.return_value = 0
+    for flag in (
+        "IRQ_PREAMBLE_DETECTED",
+        "IRQ_HEADER_VALID",
+        "IRQ_RX_DONE",
+        "IRQ_CRC_ERR",
+        "IRQ_HEADER_ERR",
+    ):
+        setattr(lora, flag, 0)
+    radio.lora = lora
+    radio._initialized = True
+    radio._is_receiving_packet = False
+    radio._pending_rx_irq_status = None
+    radio._last_sample_check = 0.0
+    radio._last_packet_activity = 0.0
+    return radio
+
+
+def test_defaults_to_zero_so_existing_boards_are_unaffected():
+    assert SX1262Radio().lna_gain_db == 0.0
+
+
+def test_gain_is_coerced_to_float():
+    assert isinstance(SX1262Radio(lna_gain_db=16).lna_gain_db, float)
+    assert SX1262Radio(lna_gain_db=14.5).lna_gain_db == pytest.approx(14.5)
+
+
+def test_noise_floor_is_referred_back_to_the_antenna():
+    radio = _prime_for_noise_sample(SX1262Radio(lna_gain_db=14.5), RAW_RSSI_MINUS_95)
+    radio._sample_noise_floor()
+    assert radio.get_noise_floor() == pytest.approx(-109.5)
+
+
+def test_noise_floor_unchanged_when_no_front_end_is_declared():
+    radio = _prime_for_noise_sample(SX1262Radio(), RAW_RSSI_MINUS_95)
+    radio._sample_noise_floor()
+    assert radio.get_noise_floor() == pytest.approx(-95.0)
+
+
+def test_negative_offset_is_allowed_for_known_feedline_loss():
+    radio = _prime_for_noise_sample(SX1262Radio(lna_gain_db=-3.0), RAW_RSSI_MINUS_95)
+    radio._sample_noise_floor()
+    assert radio.get_noise_floor() == pytest.approx(-92.0)
+
+
+def test_status_reports_the_declared_gain():
+    assert SX1262Radio(lna_gain_db=14.5).get_status()["lna_gain_db"] == pytest.approx(14.5)
+
+
+def test_snr_is_not_offset_because_gain_cancels_in_a_ratio():
+    """A front-end LNA raises signal and noise together, so SNR is unchanged."""
+    radio = SX1262Radio(lna_gain_db=14.5)
+    radio.last_snr = 7.5
+    assert radio.get_last_snr() == pytest.approx(7.5)


### PR DESCRIPTION
## Problem

Boards built around modules such as the Ebyte E22P, or front ends like the SKY66122, place an
LNA between the antenna and the SX1262. The chip cannot know it is there, so every RSSI figure
it reports is inflated by that LNA's gain: received packet RSSI, signal RSSI, and the idle
noise floor alike.

The practical result is that the reported noise floor looks alarming and cross-hardware
comparisons are silently wrong. This is a known and so far unaddressed issue across the
MeshCore ecosystem: meshcore-dev/MeshCore#2045 raised it for a RAK 1W booster kit, where a
maintainer notes the SKY66122's LNA gain is 16 dB and that "if not [accounted for], noise floor
will be higher by the LNA gain value. This is expected." That issue was closed as not planned,
so nothing in the family compensates today.

## Measurement

I swapped a Heltec V3 (bare SX1262, over USB) for a MeshSmith PiMesh-1W V2 (E22P, over SPI) on
the same node, same antenna, same mast. The reported noise floor moved from -109 dBm to about
-95 dBm, which looks like a 14 dB regression.

It is not a regression. Comparing the median RSSI per source node across the two eras, using
the repeater's own packet database, six independent distant sources with large sample counts
all shifted by the same amount:

| src | Heltec median (n) | PiMesh median | delta |
|-----|-------------------|---------------|-------|
| 6B  | -105.0 (3737) | -91.0 | +14.0 |
| 88  | -105.0 (723)  | -90.0 | +15.0 |
| 87  | -106.0 (489)  | -91.5 | +14.5 |
| E5  | -106.0 (1201) | -91.5 | +14.5 |
| 97  | -106.0 (207)  | -92.0 | +14.0 |
| 8A  | -106.0 (193)  | -93.0 | +13.0 |

A uniform offset of roughly +14.5 dB, matching the noise floor difference. Referred back to the
antenna, -95 becomes -109.5 against the Heltec's -109. Identical performance, different
reference plane.

## Change

Adds an optional `lna_gain_db` argument to `SX1262Radio`, default `0.0`, subtracted from:

* received packet RSSI and signal RSSI on the `IRQ_RX_DONE` path
* the same two figures on the CRC-error diagnostic path, so logs stay consistent
* each accepted `_sample_noise_floor()` sample, after the existing range check

`get_status()` reports the configured value so consumers can tell whether a figure is
antenna-referred.

**SNR is deliberately not adjusted.** A front-end LNA raises signal and noise together, so the
ratio is unchanged. Offsetting SNR would be actively wrong, and there is a test pinning that.

The `0.0` default means no behaviour change for any board that does not declare a front end.
Negative values are allowed so a known feedline loss can be expressed the same way.

## Testing

* New `tests/test_lna_gain_offset.py`, 7 tests covering the default, float coercion, the noise
  floor with and without a declared front end, a negative offset, the status field, and that
  SNR is untouched.
* Full existing suite passes unchanged on Python 3.13.
* `black --line-length 100`, `isort` and `flake8` all clean on the changed files.

## Follow-up, not in this PR

This adds the mechanism only. Plumbing it through `openhop_repeater`'s `config.py` and adding
per-board values to `radio-settings.json` is a separate change in the other repo. I have
deliberately not baked a figure into any preset here: my +14.5 dB is one measurement on one
PiMesh-1W V2 unit, and I would rather maintainers or the vendors confirm a value per board
before it ships as a default.

The USB modem path in `usb_radio.py` has the same blind spot, since the figure comes from modem
firmware that does not know about a front end either. Worth the same treatment, but it needs a
firmware-side decision so I have left it alone.
