### PR TITLE
Fix SX1262 RX IRQ race and TX busy state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openhop_core"
-version = "1.1.3"
+version = "1.1.4.dev0"
 authors = [
     {name = "Rightup", email = "rightup@openhop.dev"},
 ]

--- a/src/openhop_core/__init__.py
+++ b/src/openhop_core/__init__.py
@@ -3,7 +3,7 @@ openHop Core - A Python MeshCore library with SPI LoRa radio support
 Clean, simple API for building mesh network applications.
 """
 
-__version__ = "1.1.3"
+__version__ = "1.1.4.dev0"
 
 # Core mesh functionality
 from .node.node import MeshNode

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -593,18 +593,17 @@ class SX1262Radio(LoRaRadio):
                         callback_packet_data = None
                         try:
                             async with self._rx_lock:
-                                # Use the IRQ status stored by the interrupt handler
-                                irqStat = self._last_irq_status
-
-                                # Claim and clear the corresponding software latch bits here
-                                # so pre-TX/CAD drain cannot consume the same RX terminal event.
-                                consumed_latch_mask = irqStat & (
+                                # Claim the latched packet-bearing RX bits under the RX
+                                # lock: _last_irq_status may already have been overwritten
+                                # by a later PREAMBLE_DETECTED/HEADER_VALID, and claiming
+                                # here stops the pre-TX/CAD drain consuming the same event.
+                                claimed_rx_irq = self._pending_rx_irq_status & (
                                     self.lora.IRQ_RX_DONE
                                     | self.lora.IRQ_CRC_ERR
                                     | self.lora.IRQ_HEADER_ERR
                                 )
-                                if consumed_latch_mask:
-                                    self._pending_rx_irq_status &= ~consumed_latch_mask
+                                self._pending_rx_irq_status &= ~claimed_rx_irq
+                                irqStat = claimed_rx_irq or self._last_irq_status
 
                                 if irqStat & self.lora.IRQ_CRC_ERR:
                                     self.crc_error_count += 1
@@ -1508,7 +1507,6 @@ class SX1262Radio(LoRaRadio):
                 if not tx_ok:
                     raise RuntimeError("TX completion timeout")
 
-                self._tx_buffer_busy = False
                 self._finalize_transmission()
 
                 # Trigger TX LED
@@ -1528,6 +1526,8 @@ class SX1262Radio(LoRaRadio):
                 logger.error(f"[TX] Send failed: {e}")
                 raise
             finally:
+                # Never leave the TX buffer marked busy: it gates RX wakeups.
+                self._tx_buffer_busy = False
                 # Always leave radio in RX continuous mode after TX
                 await self._restore_rx_mode()
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,7 +2,7 @@ from openhop_core import CryptoUtils, LocalIdentity, MeshNode, Packet, __version
 
 
 def test_version():
-    assert __version__ == "1.1.3"
+    assert __version__ == "1.1.4.dev0"
 
 
 def test_import():

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -606,6 +606,27 @@ class TestTransmissionLifecycle:
             await radio.send(b"data")
         mock_lora.request.assert_called_with(mock_lora.RX_CONTINUOUS)
 
+    async def test_tx_buffer_busy_cleared_on_tx_timeout(self, radio):
+        radio.perform_cad = AsyncMock(return_value=False)
+        radio._wait_for_transmission_complete = AsyncMock(return_value=False)
+        with pytest.raises(RuntimeError):
+            await radio.send(b"data")
+        assert radio._tx_buffer_busy is False
+
+    async def test_tx_buffer_busy_cleared_when_tx_raises(self, radio):
+        radio.perform_cad = AsyncMock(return_value=False)
+        radio._wait_for_transmission_complete = AsyncMock(
+            side_effect=OSError("bus error")
+        )
+        with pytest.raises(OSError, match="bus error"):
+            await radio.send(b"data")
+        assert radio._tx_buffer_busy is False
+
+    async def test_tx_buffer_busy_cleared_on_success(self, radio, mock_lora):
+        _make_tx_succeed(radio, mock_lora)
+        await radio.send(b"data")
+        assert radio._tx_buffer_busy is False
+
     async def test_execute_transmission_busy_forever_returns_false(
         self, radio, mock_lora
     ):
@@ -1410,6 +1431,39 @@ class TestEventOrdering:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+    async def test_rx_done_survives_later_progress_irq_before_rx_task_runs(
+        self, radio, mock_lora
+    ):
+        """A PREAMBLE/HEADER_VALID IRQ must not steal the latched RX_DONE event."""
+        received = []
+        radio.set_rx_callback(received.append)
+
+        mock_lora.getRxBufferStatus.return_value = (4, 0x80)
+        mock_lora.readBuffer.return_value = list(b"test")
+
+        mock_lora.getIrqStatus.return_value = IRQ_RX_DONE
+        radio._handle_interrupt()
+
+        # A new reception starts before the async RX task gets scheduled; this
+        # overwrites _last_irq_status but must not lose the latched RX_DONE.
+        mock_lora.getIrqStatus.return_value = IRQ_PREAMBLE_DETECTED | IRQ_HEADER_VALID
+        radio._handle_interrupt()
+        assert radio._last_irq_status == IRQ_PREAMBLE_DETECTED | IRQ_HEADER_VALID
+        assert radio._pending_rx_irq_status & IRQ_RX_DONE
+
+        radio._rx_done_event.set()
+        task = asyncio.get_running_loop().create_task(radio._rx_irq_background_task())
+        try:
+            await _wait_condition(lambda: received == [b"test"], timeout=1.0)
+        finally:
+            radio._initialized = False
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        # The latch must not remain stale once the event has been consumed.
+        assert radio._pending_rx_irq_status == 0
 
     async def test_standalone_cad_acquires_tx_lock_before_pending_rx_drain(
         self, radio, mock_lora


### PR DESCRIPTION
## Summary

Fixes #144.

This makes two small changes to the SX1262 RX/TX state handling:

* Always clear `_tx_buffer_busy` in `send()`'s `finally` block so a failed or timed-out TX cannot leave RX wakeups suppressed.
* Process latched RX terminal IRQs from `_pending_rx_irq_status` rather than `_last_irq_status`, preventing a later PREAMBLE/HEADER interrupt from overwriting a pending `RX_DONE` before the RX task handles it.

The pending RX bits are claimed and cleared under the existing RX lock.