### PR TITLE
feat(companion): per-message flood scope override for channel messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Node Usage Guide](https://docs.openhop.dev/projects/openhop-core/node-usage/) - Guide for using MeshNode
 - [Examples](https://docs.openhop.dev/projects/openhop-core/examples/) - Working code examples
 - [API Reference](https://docs.openhop.dev/projects/openhop-core/api-reference/) - Detailed API documentation
+- [openHop Frame extensions](docs/openhop-frame-extensions.md) - Companion frames that are openHop-specific, not MeshCore
 
 ## Quick Start
 

--- a/docs/openhop-frame-extensions.md
+++ b/docs/openhop-frame-extensions.md
@@ -1,0 +1,199 @@
+# openHop Frame extensions
+
+The companion Frame protocol openHop Core speaks is MeshCore's. This document
+covers the handful of frames that are **not** — openHop-specific additions that
+a firmware companion does not implement and will reject.
+
+Everything here is confined to the app↔device Frame link. The RF packets these
+frames produce are ordinary MeshCore packets: a firmware repeater, or a firmware
+companion on the receiving end, cannot tell they were originated through an
+extension.
+
+## Design rules
+
+- **Extensions ride on an existing command, never a new command number.**
+  Command numbers are MeshCore's to allocate; taking an unused one now would
+  collide the moment upstream uses it. The extensions below live in
+  `CMD_SEND_CHANNEL_TXT_MSG` (3)'s `txt_type` byte with the high bit set.
+  MeshCore's own `TXT_TYPE_*` values are 0–3 and the firmware answers anything
+  that is not `TXT_TYPE_PLAIN` with `ERR_CODE_UNSUPPORTED_CMD` *before* it
+  touches the radio — so an extension frame sent to a firmware device, or to an
+  older openHop Core, fails cleanly rather than transmitting something
+  unintended.
+- **`FIRMWARE_VER_CODE` does not move for an extension.** That value states
+  which MeshCore companion protocol version this device implements. Extensions
+  do not change that answer, and inflating it would tell clients that
+  unimplemented upstream commands exist.
+- **Capability is negotiated explicitly.** A client must receive the exact
+  marker below before sending any extension frame.
+
+## Capability probe
+
+Request payload (7 bytes):
+
+| Offset | Size | Value |
+| --- | ---: | --- |
+| 0 | 1 | `CMD_SEND_CHANNEL_TXT_MSG` = `0x03` |
+| 1 | 1 | `OPENHOP_CHANNEL_SCOPE_PROBE` = `0x81` |
+| 2 | 5 | reserved; must be present and zero |
+
+The five reserved bytes pad the probe to command 3's minimum parse length, so a
+device without these extensions still reads a well-formed command 3 and replies
+from its normal unsupported-`txt_type` branch.
+
+Response payload (39 bytes):
+
+| Offset | Size | Value |
+| --- | ---: | --- |
+| 0 | 1 | `RESP_CODE_OPENHOP_EXTENSION` = `0xF0` |
+| 1 | 6 | ASCII `OHREG2` |
+| 7 | 32 | this companion's public key |
+
+The public key lets a client bind the answer to one identity: a single openHop
+host can front several virtual companions, and capability is a property of the
+device the client is actually talking to.
+
+Other replies and what they mean:
+
+| Reply | Meaning |
+| --- | --- |
+| `RESP_CODE_ERR` / `ERR_CODE_UNSUPPORTED_CMD` | firmware, or openHop Core without these extensions — do not send extension frames |
+| `RESP_CODE_ERR` / `ERR_CODE_ILLEGAL_ARG` | the probe itself was malformed (wrong length, or non-zero reserved bytes) |
+| `0xF0` with a marker other than `OHREG2` | a different contract revision — do not send extension frames |
+
+`OHREG2` is a whole-contract version, not a per-frame one. Any incompatible
+change to a layout on this page bumps the digit; a client must treat an
+unrecognised marker as "no extensions", never as "close enough".
+
+> An earlier unmerged draft (`openhop_repeater` PR #417) used `OHREG1` with a
+> *normalized* region name on the wire instead of a key. That normalization
+> conflated regions that MeshCore keeps distinct — see "Region names are
+> case-sensitive" below — so the contract was re-versioned rather than
+> redefined in place.
+
+## Scoped channel text send
+
+Sends one channel text message under a caller-supplied transport key, whatever
+flood scope the device itself is configured for.
+
+Request payload (23–176 bytes):
+
+| Offset | Size | Value |
+| --- | ---: | --- |
+| 0 | 1 | `CMD_SEND_CHANNEL_TXT_MSG` = `0x03` |
+| 1 | 1 | `OPENHOP_CHANNEL_TXT_SCOPED` = `0x80` |
+| 2 | 1 | channel index |
+| 3 | 4 | message timestamp, little-endian uint32 |
+| 7 | 16 | MeshCore transport key, exact bytes |
+| 23 | 1–153 | message text, UTF-8 |
+
+The whole payload is capped at `MAX_FRAME_SIZE` (176), leaving at most 153 text
+bytes. Text beyond what a packet holds is truncated by the shared send path on
+exactly firmware's terms (see "RF output" below), so a client that stays under
+153 bytes is not guaranteed the whole message arrives — the cap is the frame
+limit, not the message limit.
+
+Responses:
+
+| Condition | Reply |
+| --- | --- |
+| sent | `RESP_CODE_OK` |
+| unknown channel, or the send failed | `ERR_CODE_NOT_FOUND` |
+| malformed payload, bad key, bad text | `ERR_CODE_ILLEGAL_ARG` |
+
+`ERR_CODE_NOT_FOUND` covering both a bad channel index and a transmit failure is
+firmware's mapping for command 3, kept here so a client needs one code path for
+scoped and plain sends alike.
+
+The frame is rejected with `ERR_CODE_ILLEGAL_ARG` when:
+
+- the payload is shorter than the 23-byte minimum, or longer than 176;
+- the text is empty, contains an embedded NUL, or is not valid UTF-8;
+- the transport key is not exactly 16 bytes, or is all zeros.
+
+Trailing NUL bytes on the text are accepted and stripped, matching command 3's
+C-string convention. An *embedded* NUL is refused rather than silently accepted,
+since a client that produced one would itself read the message back truncated.
+
+All-zero keys are refused rather than read as MeshCore's
+`TransportKey::isNull()` ("send plain flood"). An explicit per-message override
+has no reason to carry the null key, so zeros are much likelier to be an
+uninitialised buffer than a deliberate request. To send unscoped, either omit
+the override (use plain command 3) or set the device unscoped with
+`CMD_SET_FLOOD_SCOPE` mode 1.
+
+### Deriving the key
+
+The key is a raw 16-byte MeshCore `TransportKey`. For a public auto-hashtag
+region it is the first 16 bytes of `SHA-256` over the ASCII region name
+including the leading `#`:
+
+```python
+from openhop_core.protocol.transport_keys import get_auto_key_for
+
+key = get_auto_key_for("#USA")   # 16 bytes
+```
+
+Private regions supply their key by whatever means they distribute it; pass
+those 16 bytes through unchanged.
+
+### Region names are case-sensitive
+
+`#USA` and `#usa` hash to different keys and are therefore **different
+regions**. Nothing in openHop Core case-folds a region name, and clients must
+not either — a client that lowercases user input silently moves traffic to a
+region the user did not name, and nodes in the intended region never see it.
+
+```python
+get_auto_key_for("#USA") != get_auto_key_for("#usa")   # True
+```
+
+## RF output
+
+A scoped send produces exactly what MeshCore emits for a scoped group text:
+
+- the `GRP_TXT` payload is built and encrypted normally — same channel hash,
+  same MAC, same `"<sender>: "` prefix, same firmware-compatible truncation of
+  the text (never the prefix) at the packet's byte limit;
+- the route type changes from `FLOOD` (0) to `TRANSPORT_FLOOD` (2);
+- transport code slot 0 is `HMAC-SHA256(key, payload_type || payload)`, first
+  two bytes read little-endian, with `0x0000` and `0xFFFF` mapped to `0x0001`
+  and `0xFFFE` as firmware reserves them;
+- transport code slot 1 is 0, firmware's placeholder for the sender's home
+  region.
+
+## Relation to `CMD_SET_FLOOD_SCOPE` (54)
+
+Command 54 is MeshCore's and is **sticky**: it sets `send_scope` (or
+`send_unscoped`) on the device, and every subsequent flood uses it until the
+next command 54. Firmware has no per-message form — `MyMesh::sendFloodScoped`
+carries a `// TODO: have per-channel send_scope` where one would go.
+
+The extension is the per-message form. It reads and writes no device state at
+all: not `send_scope`, not `send_unscoped`, not the persisted default scope, and
+not any dispatcher mirror. Two scoped sends in flight at once, with different
+keys, cannot affect each other or any concurrent ordinary send.
+
+This means the two do not interact. A client that wants a *sticky* scope still
+uses command 54; a client that wants one message elsewhere uses the extension
+and leaves the device's own scope exactly as the user configured it.
+
+## Python API
+
+The same behaviour is available directly, on both `CompanionRadio` and
+`CompanionBridge`:
+
+```python
+from openhop_core.protocol.transport_keys import get_auto_key_for
+
+await companion.send_channel_message(
+    1,
+    "hello",
+    flood_scope_key=get_auto_key_for("#USA"),
+)
+```
+
+`flood_scope_key=None` (the default) keeps the node's own resolution:
+force-unscoped flag, then transient override, then persisted default, then plain
+flood. A key that is not 16 non-zero bytes raises `ValueError` before any packet
+is built.

--- a/docs/openhop-frame-extensions.md
+++ b/docs/openhop-frame-extensions.md
@@ -76,7 +76,7 @@ unrecognised marker as "no extensions", never as "close enough".
 Sends one channel text message under a caller-supplied transport key, whatever
 flood scope the device itself is configured for.
 
-Request payload (23–176 bytes):
+Request payload (24–176 bytes):
 
 | Offset | Size | Value |
 | --- | ---: | --- |
@@ -87,8 +87,9 @@ Request payload (23–176 bytes):
 | 7 | 16 | MeshCore transport key, exact bytes |
 | 23 | 1–153 | message text, UTF-8 |
 
-The whole payload is capped at `MAX_FRAME_SIZE` (176), leaving at most 153 text
-bytes. Text beyond what a packet holds is truncated by the shared send path on
+The fixed part occupies offsets 0–22, so the smallest complete request is 24
+bytes: 23 of header plus at least one text byte. The whole payload is capped at
+`MAX_FRAME_SIZE` (176), leaving at most 153 text bytes. Text beyond what a packet holds is truncated by the shared send path on
 exactly firmware's terms (see "RF output" below), so a client that stays under
 153 bytes is not guaranteed the whole message arrives — the cap is the frame
 limit, not the message limit.
@@ -107,9 +108,17 @@ scoped and plain sends alike.
 
 The frame is rejected with `ERR_CODE_ILLEGAL_ARG` when:
 
-- the payload is shorter than the 23-byte minimum, or longer than 176;
+- the payload is shorter than the 24-byte minimum;
 - the text is empty, contains an embedded NUL, or is not valid UTF-8;
 - the transport key is not exactly 16 bytes, or is all zeros.
+
+A payload longer than `MAX_FRAME_SIZE` does **not** get an error frame on the
+TCP transport: the frame reader rejects the length prefix and closes the
+connection before any handler runs, so the client sees a disconnect. (The
+handler carries the same check for other callers, and firmware transports are
+no more consistent here — the Wi-Fi interface skips an oversized frame while
+the Arduino serial one truncates it.) Clients should treat 176 as a hard limit
+rather than something to probe.
 
 Trailing NUL bytes on the text are accepted and stripped, matching command 3's
 C-string convention. An *embedded* NUL is refused rather than silently accepted,
@@ -118,9 +127,12 @@ since a client that produced one would itself read the message back truncated.
 All-zero keys are refused rather than read as MeshCore's
 `TransportKey::isNull()` ("send plain flood"). An explicit per-message override
 has no reason to carry the null key, so zeros are much likelier to be an
-uninitialised buffer than a deliberate request. To send unscoped, either omit
-the override (use plain command 3) or set the device unscoped with
-`CMD_SET_FLOOD_SCOPE` mode 1.
+uninitialised buffer than a deliberate request. Note the limitation this leaves: there is no per-message
+way to force *unscoped*. Omitting the override runs the node's own resolver,
+which sends unscoped only when the node has no transient or default scope; the
+sole way to guarantee a plain flood is `CMD_SET_FLOOD_SCOPE` mode 1, which
+changes sticky device state. Say so rather than implying the two are
+equivalent.
 
 ### Deriving the key
 
@@ -150,7 +162,8 @@ get_auto_key_for("#USA") != get_auto_key_for("#usa")   # True
 
 ## RF output
 
-A scoped send produces exactly what MeshCore emits for a scoped group text:
+A scoped send produces what MeshCore emits for a scoped group text, given the
+same message text:
 
 - the `GRP_TXT` payload is built and encrypted normally — same channel hash,
   same MAC, same `"<sender>: "` prefix, same firmware-compatible truncation of
@@ -161,6 +174,14 @@ A scoped send produces exactly what MeshCore emits for a scoped group text:
   and `0xFFFE` as firmware reserves them;
 - transport code slot 1 is 0, firmware's placeholder for the sender's home
   region.
+
+One caveat on "same message text": openHop Core strips trailing NULs before
+building the datagram, on this extension and on command 3 alike, whereas
+firmware passes the client's byte count through to `sendGroupMessage` and
+encrypts the NULs. A client that pads its text therefore gets a shorter
+ciphertext from openHop than from firmware. The decrypted string is the same
+either way, so this does not affect interoperability — but it means the RF
+bytes are identical only for text without trailing NULs.
 
 ## Relation to `CMD_SET_FLOOD_SCOPE` (54)
 

--- a/src/openhop_core/companion/base_config.py
+++ b/src/openhop_core/companion/base_config.py
@@ -24,6 +24,37 @@ from .models import NodePrefs
 
 logger = logging.getLogger("CompanionBase")
 
+FLOOD_SCOPE_KEY_SIZE = 16
+
+
+def normalize_flood_scope_key(transport_key) -> bytes:
+    """Validate an explicit per-message flood scope key and return it as bytes.
+
+    Raises ``ValueError`` for anything that is not exactly
+    ``FLOOD_SCOPE_KEY_SIZE`` non-zero bytes. Callers must invoke this *before*
+    entering any ``try``/``except Exception`` that converts failures into a
+    falsey send result, so that a malformed key is reported to the caller as an
+    argument error rather than as an ordinary transmit failure.
+
+    The all-zero key is rejected rather than treated as firmware's
+    ``TransportKey::isNull()`` (which means "send plain flood"). An explicit
+    per-message override has no reason to carry the null key, so the zeros are
+    far likelier to be an uninitialised buffer than a deliberate request; the
+    firmware-equivalent "unscoped" behaviour is reached by omitting the
+    override, or by ``set_flood_unscoped()``.
+    """
+    if transport_key is None:
+        raise ValueError("flood scope key must not be None")
+    try:
+        key = bytes(transport_key)
+    except TypeError as exc:
+        raise ValueError(f"flood scope key must be bytes-like: {exc}") from exc
+    if len(key) != FLOOD_SCOPE_KEY_SIZE:
+        raise ValueError(f"flood scope key must be {FLOOD_SCOPE_KEY_SIZE} bytes, got {len(key)}")
+    if key == ZERO_FLOOD_SCOPE_KEY:
+        raise ValueError("flood scope key must not be all zeros (MeshCore reserves the null key)")
+    return key
+
 
 class _DeviceConfigMixin:
     """Part of :class:`CompanionBase` (see companion_base.py)."""
@@ -367,6 +398,34 @@ class _DeviceConfigMixin:
         if effective_key is None:
             return
         self._scope_packet(pkt, effective_key)
+
+    def _apply_explicit_flood_scope(self, pkt: Packet, transport_key) -> None:
+        """Scope one packet with a caller-supplied key, ignoring node scope state.
+
+        The per-message counterpart to :meth:`_apply_flood_scope`: it takes the
+        place of the whole resolution chain (force-unscoped flag, transient
+        override, persisted default) for this packet only, and touches no stored
+        state. Firmware has no equivalent -- ``MyMesh::sendFloodScoped`` reads
+        ``send_unscoped``/``send_scope``/``default_scope_key``, with a
+        ``// TODO: have per-channel send_scope`` where this would go -- so the
+        RF result is exactly what firmware emits for
+        ``sendFloodScoped(scope, pkt)`` once a scope has been resolved.
+
+        The key is validated by :func:`normalize_flood_scope_key`, which the
+        caller is expected to have run already; re-running it here is cheap and
+        keeps the helper safe to call directly.
+
+        Marks the packet scope-applied on the same terms as its sibling, so the
+        dispatcher's node-level resolver cannot replace the decision downstream
+        (notably on a repeater, whose dispatcher scopes every flood it sends).
+        """
+        key = normalize_flood_scope_key(transport_key)
+        if getattr(pkt, "_flood_scope_applied", False):
+            return
+        if pkt.get_route_type() != ROUTE_TYPE_FLOOD:
+            return  # only scope plain floods, exactly as _apply_flood_scope does
+        pkt._flood_scope_applied = True
+        self._scope_packet(pkt, key)
 
     def _apply_default_flood_scope(self, pkt: Packet) -> None:
         """Scope a flood packet with the persisted default scope only.

--- a/src/openhop_core/companion/base_config.py
+++ b/src/openhop_core/companion/base_config.py
@@ -415,9 +415,12 @@ class _DeviceConfigMixin:
         caller is expected to have run already; re-running it here is cheap and
         keeps the helper safe to call directly.
 
-        Marks the packet scope-applied on the same terms as its sibling, so the
-        dispatcher's node-level resolver cannot replace the decision downstream
-        (notably on a repeater, whose dispatcher scopes every flood it sends).
+        Marks the packet scope-applied on the same terms as its sibling. For a
+        packet that ends up scoped the mark is belt-and-braces -- the route is
+        now TRANSPORT_FLOOD and the dispatcher only re-scopes ROUTE_TYPE_FLOOD,
+        so the codes survive on that alone. It earns its keep by recording
+        *ownership*: it is what a later resolver, or a caller that resets the
+        route, reads to know this packet's scope was already decided here.
         """
         key = normalize_flood_scope_key(transport_key)
         if getattr(pkt, "_flood_scope_applied", False):

--- a/src/openhop_core/companion/base_send.py
+++ b/src/openhop_core/companion/base_send.py
@@ -28,6 +28,7 @@ from ..protocol.constants import (
     TELEM_PERM_BASE,
 )
 from ..protocol.packet_utils import PathUtils
+from .base_config import normalize_flood_scope_key
 from .base_support import ResponseWaiter, _fmt_path, _fmt_path_len, adv_type_to_flags
 from .constants import (
     ADV_TYPE_NONE,
@@ -473,9 +474,33 @@ class _SendOpsMixin:
             return SentResult(success=False)
 
     async def send_channel_message(
-        self, channel_idx: int, text: str, timestamp: Optional[int] = None
+        self,
+        channel_idx: int,
+        text: str,
+        timestamp: Optional[int] = None,
+        *,
+        flood_scope_key: Optional[bytes] = None,
     ) -> bool:
-        """Send a message to a channel."""
+        """Send a message to a channel.
+
+        ``flood_scope_key`` overrides the flood scope for this one message. With
+        ``None`` (the default) the node's own resolution applies, unchanged:
+        force-unscoped flag, then transient override, then persisted default,
+        then plain flood. A 16-byte non-null key replaces all of that for this
+        packet and this packet only -- no node, dispatcher or preference state
+        is read or written, so concurrent sends cannot see each other's scope.
+
+        Raises ``ValueError`` for a key that is not exactly 16 non-zero bytes.
+        That check runs before any packet is built and outside the send's
+        exception handling, so a bad key surfaces as an argument error rather
+        than as the ``False`` that means "transmit failed".
+        """
+        if flood_scope_key is not None:
+            # Validated out here on purpose: the try below turns every exception
+            # into `return False`, which would hide a malformed key behind an
+            # ordinary send failure and leave callers (the Frame extension
+            # included) unable to tell the two apart.
+            flood_scope_key = normalize_flood_scope_key(flood_scope_key)
         channel = self.channels.get(channel_idx)
         if not channel:
             logger.warning("Channel %s not found", channel_idx)
@@ -489,7 +514,12 @@ class _SendOpsMixin:
                 channels_config=self.channels.get_channels(),
                 timestamp=timestamp,
             )
-            self._apply_flood_scope(pkt)
+            # Attached to the freshly built packet with no await in between, so
+            # the override travels with this packet rather than with the node.
+            if flood_scope_key is None:
+                self._apply_flood_scope(pkt)
+            else:
+                self._apply_explicit_flood_scope(pkt, flood_scope_key)
             self._apply_path_hash_mode(pkt)
             # Record before awaiting the transport because Repeater can queue
             # a local transmission back through its companion bridges first.

--- a/src/openhop_core/companion/constants.py
+++ b/src/openhop_core/companion/constants.py
@@ -329,3 +329,34 @@ OUT_PATH_UNKNOWN = 0xFF
 # ---------------------------------------------------------------------------
 PUBLIC_GROUP_PSK = b"izOH6cXN6mrJ5e26oRXNcg=="
 DEFAULT_PUBLIC_CHANNEL_SECRET = base64.b64decode(PUBLIC_GROUP_PSK)
+
+# ===========================================================================
+# OpenHop Frame extensions
+# ---------------------------------------------------------------------------
+# These are NOT part of the upstream MeshCore companion protocol. They ride on
+# CMD_SEND_CHANNEL_TXT_MSG's txt_type byte with the high bit set, so a firmware
+# companion -- or any Core build predating them -- answers
+# ERR_CODE_UNSUPPORTED_CMD from its existing "txt_type != TXT_TYPE_PLAIN" branch
+# and never reaches RF. FIRMWARE_VER_CODE deliberately does not move for these:
+# it states MeshCore companion-protocol compatibility, which is unchanged.
+# Clients must negotiate with OPENHOP_CHANNEL_SCOPE_PROBE before using them.
+# Wire layouts: docs/openhop-frame-extensions.md
+# ===========================================================================
+
+# txt_type subtype: per-message flood scope override on a channel text send.
+OPENHOP_CHANNEL_TXT_SCOPED = 0x80
+# txt_type subtype: capability probe for the extensions above.
+OPENHOP_CHANNEL_SCOPE_PROBE = 0x81
+# Response code for a capability-probe reply. Clear of both the firmware
+# RESP_CODE_* range (0..28) and the PUSH_CODE_* range (0x80..0x90).
+RESP_CODE_OPENHOP_EXTENSION = 0xF0
+# Contract marker returned by the probe. Bump the digit for any incompatible
+# change to the byte layouts; a client must see this exact value before
+# sending OPENHOP_CHANNEL_TXT_SCOPED.
+OPENHOP_EXTENSION_MARKER = b"OHREG2"
+# Reserved bytes that pad a probe out to command 3's minimum parse length, so a
+# server without these extensions still reads it as a well-formed command 3.
+OPENHOP_SCOPE_PROBE_RESERVED_LEN = 5
+# Fixed header of a scoped send, after the command byte:
+#   subtype(1) + channel_idx(1) + timestamp(4) + transport key(16)
+OPENHOP_SCOPED_SEND_HEADER_LEN = 22

--- a/src/openhop_core/companion/frame_server/commands_messaging.py
+++ b/src/openhop_core/companion/frame_server/commands_messaging.py
@@ -17,8 +17,14 @@ from ..constants import (
     FIRMWARE_VER_CODE,
     LOGIN_TIMEOUT_HINT_MS,
     MAX_CHANNEL_DATA_LENGTH,
+    MAX_FRAME_SIZE,
     MAX_GROUP_DATA_LENGTH,
     MAX_PATH_SIZE,
+    OPENHOP_CHANNEL_SCOPE_PROBE,
+    OPENHOP_CHANNEL_TXT_SCOPED,
+    OPENHOP_EXTENSION_MARKER,
+    OPENHOP_SCOPE_PROBE_RESERVED_LEN,
+    OPENHOP_SCOPED_SEND_HEADER_LEN,
     OUT_PATH_UNKNOWN,
     PUB_KEY_SIZE,
     PUSH_CODE_LOGIN_FAIL,
@@ -31,6 +37,7 @@ from ..constants import (
     RESP_CODE_CONTACT_MSG_RECV,
     RESP_CODE_CONTACT_MSG_RECV_V3,
     RESP_CODE_NO_MORE_MESSAGES,
+    RESP_CODE_OPENHOP_EXTENSION,
     STATUS_TIMEOUT_HINT_MS,
     TELEMETRY_TIMEOUT_HINT_MS,
     TXT_MSG_TIMEOUT_HINT_MS,
@@ -130,22 +137,119 @@ class _MessagingCommandsMixin:
             self._write_err(ERR_CODE_TABLE_FULL)
 
     async def _cmd_send_channel_txt_msg(self, data: bytes) -> None:
+        """Dispatch CMD_SEND_CHANNEL_TXT_MSG (3) on its txt_type byte.
+
+        ``TXT_TYPE_PLAIN`` is the firmware command and is handled byte-for-byte
+        as before. Two high-bit subtypes are OpenHop extensions (see
+        ``docs/openhop-frame-extensions.md``); every other value keeps
+        firmware's ERR_CODE_UNSUPPORTED_CMD, which is also what a firmware
+        companion answers to the extension subtypes themselves.
+        """
         if len(data) < 6:
             self._write_err(ERR_CODE_ILLEGAL_ARG)
             return
         txt_type = data[0]
+        if txt_type == OPENHOP_CHANNEL_SCOPE_PROBE:
+            self._openhop_channel_scope_probe(data)
+            return
+        if txt_type == OPENHOP_CHANNEL_TXT_SCOPED:
+            await self._openhop_send_channel_txt_scoped(data)
+            return
+        if txt_type != TXT_TYPE_PLAIN:
+            self._write_err(ERR_CODE_UNSUPPORTED_CMD)
+            return
         channel_idx = data[1]
         msg_timestamp = struct.unpack("<I", data[2:6])[0]
         text = data[6:].decode("utf-8", errors="replace").rstrip("\x00")
-        if txt_type != 0:
-            self._write_err(ERR_CODE_UNSUPPORTED_CMD)
-            return
         if self.bridge.get_channel(channel_idx) is None:
             self._write_err(ERR_CODE_NOT_FOUND)
             return
         ok = await self.bridge.send_channel_message(channel_idx, text, timestamp=msg_timestamp)
         # Firmware reports any channel-send failure as NOT_FOUND (MyMesh.cpp
         # CMD_SEND_CHANNEL_TXT_MSG), so strictly-compatible clients expect it.
+        self._write_ok() if ok else self._write_err(ERR_CODE_NOT_FOUND)
+
+    # -- OpenHop extensions to command 3 -------------------------------------
+    # Not MeshCore protocol. Kept on command 3 so that a server without them
+    # rejects the unknown txt_type from its existing branch, without RF.
+
+    def _openhop_channel_scope_probe(self, data: bytes) -> None:
+        """Answer the capability probe: [0xF0][OHREG2][32-byte public key].
+
+        The reserved tail is required to be present and zero so the probe is
+        also a well-formed command 3 for a server that does not know it, and so
+        the bytes stay available for a later revision of the contract.
+        """
+        if len(data) != 1 + OPENHOP_SCOPE_PROBE_RESERVED_LEN or any(data[1:]):
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
+            return
+        self._write_frame(
+            bytes([RESP_CODE_OPENHOP_EXTENSION])
+            + OPENHOP_EXTENSION_MARKER
+            + self.bridge.get_public_key()
+        )
+
+    async def _openhop_send_channel_txt_scoped(self, data: bytes) -> None:
+        """Send one channel text message under a caller-supplied transport key.
+
+        Payload after the command byte:
+          subtype(1) channel_idx(1) timestamp(4) transport_key(16) text(1..)
+
+        The key overrides this node's flood scope for this message only. Only
+        the envelope is parsed here: encryption, the ``"<sender>: "`` prefix and
+        its firmware-compatible truncation, echo tracking and packet injection
+        all stay in the shared send path, so scoped and plain sends differ on
+        the wire in nothing but the route type and transport codes.
+        """
+        # Defensive: a conforming client cannot exceed the frame limit, but the
+        # cap is what bounds the text and it costs nothing to state it here.
+        if len(data) + 1 > MAX_FRAME_SIZE:
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
+            return
+        if len(data) <= OPENHOP_SCOPED_SEND_HEADER_LEN:
+            # Header complete but no text, or a truncated header/key.
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
+            return
+        channel_idx = data[1]
+        msg_timestamp = struct.unpack("<I", data[2:6])[0]
+        scope_key = data[6:OPENHOP_SCOPED_SEND_HEADER_LEN]
+        # Trailing NULs are the C-string convention command 3 already accepts;
+        # an *embedded* NUL would be silently truncated by such a client, so the
+        # extension rejects it rather than sending something else's bytes.
+        raw_text = data[OPENHOP_SCOPED_SEND_HEADER_LEN:].rstrip(b"\x00")
+        if not raw_text or b"\x00" in raw_text:
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
+            return
+        try:
+            text = raw_text.decode("utf-8")
+        except UnicodeDecodeError:
+            # Stricter than command 3's errors="replace": a new contract can
+            # afford to tell the client its bytes were wrong.
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
+            return
+        if self.bridge.get_channel(channel_idx) is None:
+            self._write_err(ERR_CODE_NOT_FOUND)
+            return
+        try:
+            ok = await self.bridge.send_channel_message(
+                channel_idx,
+                text,
+                timestamp=msg_timestamp,
+                flood_scope_key=scope_key,
+            )
+        except ValueError:
+            # The key is 16 bytes by construction above, so in practice this is
+            # the reserved all-zero key; the catch stays broad because the
+            # bridge owns key validation and may grow further rules.
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
+            return
+        except TypeError:
+            # Bridge predates the keyword; report it as unsupported rather than
+            # retrying unscoped, which would send to the wrong region silently.
+            logger.warning("Bridge does not support scoped channel sends")
+            self._write_err(ERR_CODE_UNSUPPORTED_CMD)
+            return
+        # Same failure mapping as command 3, so one client path handles both.
         self._write_ok() if ok else self._write_err(ERR_CODE_NOT_FOUND)
 
     async def _cmd_send_channel_data(self, data: bytes) -> None:

--- a/src/openhop_core/companion/frame_server/commands_messaging.py
+++ b/src/openhop_core/companion/frame_server/commands_messaging.py
@@ -8,6 +8,7 @@ import struct
 from ...protocol.cayenne_lpp import TELEM_CHANNEL_SELF, encode_voltage
 from ...protocol.constants import TELEM_PERM_BASE, TELEM_PERM_ENVIRONMENT, TELEM_PERM_LOCATION
 from ...protocol.packet_utils import PathUtils
+from ..base_config import normalize_flood_scope_key
 from ..constants import (
     ERR_CODE_BAD_STATE,
     ERR_CODE_ILLEGAL_ARG,
@@ -212,7 +213,6 @@ class _MessagingCommandsMixin:
             return
         channel_idx = data[1]
         msg_timestamp = struct.unpack("<I", data[2:6])[0]
-        scope_key = data[6:OPENHOP_SCOPED_SEND_HEADER_LEN]
         # Trailing NULs are the C-string convention command 3 already accepts;
         # an *embedded* NUL would be silently truncated by such a client, so the
         # extension rejects it rather than sending something else's bytes.
@@ -227,6 +227,16 @@ class _MessagingCommandsMixin:
             # afford to tell the client its bytes were wrong.
             self._write_err(ERR_CODE_ILLEGAL_ARG)
             return
+        # Validated before the channel lookup so that every malformed argument
+        # answers ILLEGAL_ARG. Deferring it to the bridge would let a frame that
+        # is bad in two ways at once (unknown channel *and* a null key) report
+        # NOT_FOUND, telling the client to fix the channel when the key is
+        # wrong too.
+        try:
+            scope_key = normalize_flood_scope_key(data[6:OPENHOP_SCOPED_SEND_HEADER_LEN])
+        except ValueError:
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
+            return
         if self.bridge.get_channel(channel_idx) is None:
             self._write_err(ERR_CODE_NOT_FOUND)
             return
@@ -238,9 +248,8 @@ class _MessagingCommandsMixin:
                 flood_scope_key=scope_key,
             )
         except ValueError:
-            # The key is 16 bytes by construction above, so in practice this is
-            # the reserved all-zero key; the catch stays broad because the
-            # bridge owns key validation and may grow further rules.
+            # Already validated above; kept because the bridge owns key policy
+            # and may grow rules this handler does not know about.
             self._write_err(ERR_CODE_ILLEGAL_ARG)
             return
         except TypeError:

--- a/tests/test_companion_regions.py
+++ b/tests/test_companion_regions.py
@@ -804,16 +804,25 @@ class TestExplicitScopeOnBridge:
         release.set()
         assert all(await asyncio.gather(*tasks))
 
-        by_code = {p.transport_codes[0] for p in sent}
         assert len(sent) == 3
-        assert len(by_code) == 3, "concurrent sends shared a scope"
         for pkt in sent:
             assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
-        expected = {
-            calc_transport_code(k, p)
-            for k, p in zip((usa, europe, get_auto_key_for("#nl-li")), sent)
-        }
-        assert by_code == expected
+
+        # Match each packet to the key that explains its code rather than to
+        # the key at its position: completion order is not send order, so
+        # zipping the two would pass on a mismatch and fail on a correct run.
+        keys = {"usa": usa, "europe": europe, "node": get_auto_key_for("#nl-li")}
+        matched = []
+        for pkt in sent:
+            owners = [
+                name
+                for name, key in keys.items()
+                if calc_transport_code(key, pkt) == pkt.transport_codes[0]
+            ]
+            assert len(owners) == 1, f"packet matched {owners or 'no'} key(s)"
+            matched.append(owners[0])
+
+        assert sorted(matched) == ["europe", "node", "usa"], "concurrent sends shared a scope"
 
     @pytest.mark.asyncio
     async def test_cancelled_send_leaves_no_residue(self):
@@ -849,3 +858,37 @@ class TestExplicitScopeOnBridge:
         ok = await bridge.send_channel_message(0, "hello", flood_scope_key=get_auto_key_for("#USA"))
 
         assert ok is False
+
+
+class TestTrailingNulDivergence:
+    """Pin the one place text handling departs from firmware byte-for-byte.
+
+    Firmware's command 3 passes the client's byte count straight into
+    ``sendGroupMessage`` and encrypts any trailing NULs with it. openHop's
+    *frame handlers* strip them first -- both command 3 and the scoped
+    extension -- so for a padded frame the two stacks encrypt different lengths.
+
+    ``send_channel_message`` itself does not strip: it encrypts whatever string
+    it is handed, which is what this test shows. Combined with
+    ``test_openhop_scoped_send_strips_trailing_nuls`` in the frame-server suite
+    (a padded frame reaches the bridge as ``"hello"``), that pins the whole
+    divergence: openHop emits the shorter form where firmware emits the longer.
+
+    The decrypted string matches either way, so interoperability is unaffected
+    -- but "identical RF bytes" holds only for text without trailing NULs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_send_api_encrypts_trailing_nuls_frame_layer_strips_them(self):
+        key = get_auto_key_for("#USA")
+        bare = await _send_via_radio(
+            _scoped_radio_companion(), 0, "hi", 1700000000, flood_scope_key=key
+        )
+        padded = await _send_via_radio(
+            _scoped_radio_companion(), 0, "hi\x00\x00", 1700000000, flood_scope_key=key
+        )
+
+        # Core strips, so the two are the same packet; firmware would emit a
+        # longer ciphertext for the padded one.
+        assert bytes(padded.get_payload()) != bytes(bare.get_payload())
+        assert len(padded.get_payload()) > len(bare.get_payload())

--- a/tests/test_companion_regions.py
+++ b/tests/test_companion_regions.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
-from openhop_core.companion import CompanionRadio
+from openhop_core.companion import CompanionBridge, CompanionRadio
 from openhop_core.companion.models import Channel
 from openhop_core.protocol import LocalIdentity, Packet, PacketBuilder
 from openhop_core.protocol.constants import (
@@ -479,3 +481,371 @@ class TestChannelMessageFloodScope:
         pkt.read_from(raw)
         assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
         assert pkt.transport_codes == [0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Per-message flood scope override (openHop extension; no firmware equivalent)
+# ---------------------------------------------------------------------------
+
+PRIVATE_KEY = bytes.fromhex("0f1e2d3c4b5a69788796a5b4c3d2e1f0")
+
+
+def _make_bridge(injector):
+    """A CompanionBridge with one channel, sending through ``injector``."""
+    bridge = CompanionBridge(LocalIdentity(), injector, node_name="scoped")
+    bridge.channels.set(0, Channel(name="test-ch", secret=b"\xAB" * 16))
+    return bridge
+
+
+def _capturing_bridge():
+    """A bridge plus the list of packets its injector receives."""
+    sent: list[Packet] = []
+
+    async def injector(pkt, **kwargs):
+        sent.append(pkt)
+        return True
+
+    return _make_bridge(injector), sent
+
+
+async def _send_via_radio(companion, *args, **kwargs) -> Packet:
+    """Run one send through CompanionRadio and parse the packet off the wire."""
+    await companion.start()
+    try:
+        await companion.send_channel_message(*args, **kwargs)
+    finally:
+        await companion.stop()
+    assert companion._radio.sent, "expected a packet on the wire"
+    pkt = Packet()
+    pkt.read_from(companion._radio.sent[-1])
+    return pkt
+
+
+def _scoped_radio_companion() -> CompanionRadio:
+    companion = CompanionRadio(radio=MockRadio(), identity=LocalIdentity(), node_name="scoped")
+    companion.channels.set(0, Channel(name="test-ch", secret=b"\xAB" * 16))
+    return companion
+
+
+class TestExplicitFloodScopeHelper:
+    """``_apply_explicit_flood_scope`` unit behaviour."""
+
+    def test_scopes_flood_packet_with_given_key(self):
+        companion = _make_companion()
+        pkt = _make_flood_packet()
+        key = get_auto_key_for("#USA")
+        expected = calc_transport_code(key, pkt)
+
+        companion._apply_explicit_flood_scope(pkt, key)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt.transport_codes[0] == expected
+        assert pkt.transport_codes[1] == 0
+        assert pkt._flood_scope_applied
+
+    def test_leaves_direct_packet_alone(self):
+        companion = _make_companion()
+        pkt = _make_direct_packet()
+
+        companion._apply_explicit_flood_scope(pkt, get_auto_key_for("#USA"))
+
+        assert pkt.get_route_type() == ROUTE_TYPE_DIRECT
+        assert pkt.transport_codes == [0, 0]
+
+    def test_does_not_override_an_existing_decision(self):
+        """A packet a reply helper already decided keeps that decision."""
+        companion = _make_companion()
+        pkt = _make_flood_packet()
+        pkt._flood_scope_applied = True
+
+        companion._apply_explicit_flood_scope(pkt, get_auto_key_for("#USA"))
+
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+        assert pkt.transport_codes == [0, 0]
+
+    @pytest.mark.parametrize(
+        "bad_key",
+        [b"", b"\x01" * 15, b"\x01" * 17, bytes(16), None],
+        ids=["empty", "short", "long", "all-zero", "none"],
+    )
+    def test_rejects_bad_keys(self, bad_key):
+        companion = _make_companion()
+        pkt = _make_flood_packet()
+
+        with pytest.raises(ValueError):
+            companion._apply_explicit_flood_scope(pkt, bad_key)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+        assert pkt.transport_codes == [0, 0]
+
+    def test_accepts_bytes_like(self):
+        companion = _make_companion()
+        pkt = _make_flood_packet()
+
+        companion._apply_explicit_flood_scope(pkt, bytearray(get_auto_key_for("#USA")))
+
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+
+
+class TestSendChannelMessageExplicitScope:
+    """``send_channel_message(flood_scope_key=...)`` on the wire."""
+
+    @pytest.mark.asyncio
+    async def test_produces_transport_flood_with_matching_code(self):
+        companion = _scoped_radio_companion()
+        key = get_auto_key_for("#USA")
+
+        pkt = await _send_via_radio(companion, 0, "hello", flood_scope_key=key)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt.transport_codes[0] == calc_transport_code(key, pkt)
+        assert pkt.transport_codes[1] == 0
+
+    @pytest.mark.asyncio
+    async def test_payload_identical_to_unscoped_send(self):
+        """Scoping changes the route and codes -- never the encrypted payload."""
+        key = get_auto_key_for("#USA")
+        timestamp = 1700000000
+
+        plain = await _send_via_radio(_scoped_radio_companion(), 0, "hello", timestamp)
+        scoped = await _send_via_radio(
+            _scoped_radio_companion(), 0, "hello", timestamp, flood_scope_key=key
+        )
+
+        assert scoped.get_payload_type() == plain.get_payload_type()
+        assert bytes(scoped.get_payload()) == bytes(plain.get_payload())
+        assert plain.get_route_type() == ROUTE_TYPE_FLOOD
+        assert scoped.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+
+    @pytest.mark.asyncio
+    async def test_region_name_case_is_not_folded(self):
+        """#USA and #usa are different MeshCore regions, not one region."""
+        upper = get_auto_key_for("#USA")
+        lower = get_auto_key_for("#usa")
+        assert upper != lower
+
+        pkt_upper = await _send_via_radio(
+            _scoped_radio_companion(), 0, "hello", 1700000000, flood_scope_key=upper
+        )
+        pkt_lower = await _send_via_radio(
+            _scoped_radio_companion(), 0, "hello", 1700000000, flood_scope_key=lower
+        )
+
+        assert pkt_upper.transport_codes[0] == calc_transport_code(upper, pkt_upper)
+        assert pkt_lower.transport_codes[0] == calc_transport_code(lower, pkt_lower)
+        assert pkt_upper.transport_codes[0] != pkt_lower.transport_codes[0]
+
+    @pytest.mark.asyncio
+    async def test_private_key_used_verbatim(self):
+        """A key from a private region is not derived from anything."""
+        companion = _scoped_radio_companion()
+
+        pkt = await _send_via_radio(companion, 0, "hello", flood_scope_key=PRIVATE_KEY)
+
+        assert pkt.transport_codes[0] == calc_transport_code(PRIVATE_KEY, pkt)
+
+    @pytest.mark.asyncio
+    async def test_overrides_transient_region(self):
+        companion = _scoped_radio_companion()
+        companion.set_flood_region("#nl-li")
+        key = get_auto_key_for("#USA")
+
+        pkt = await _send_via_radio(companion, 0, "hello", flood_scope_key=key)
+
+        assert pkt.transport_codes[0] == calc_transport_code(key, pkt)
+        assert pkt.transport_codes[0] != calc_transport_code(get_auto_key_for("#nl-li"), pkt)
+
+    @pytest.mark.asyncio
+    async def test_overrides_persisted_default(self):
+        companion = _scoped_radio_companion()
+        companion.set_default_flood_scope("nl-li", get_auto_key_for("#nl-li"))
+        key = get_auto_key_for("#USA")
+
+        pkt = await _send_via_radio(companion, 0, "hello", flood_scope_key=key)
+
+        assert pkt.transport_codes[0] == calc_transport_code(key, pkt)
+
+    @pytest.mark.asyncio
+    async def test_overrides_force_unscoped(self):
+        """The explicit key outranks the sticky send_unscoped flag."""
+        companion = _scoped_radio_companion()
+        companion.set_default_flood_scope("nl-li", get_auto_key_for("#nl-li"))
+        companion.set_flood_unscoped()
+        key = get_auto_key_for("#USA")
+
+        pkt = await _send_via_radio(companion, 0, "hello", flood_scope_key=key)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt.transport_codes[0] == calc_transport_code(key, pkt)
+
+    @pytest.mark.asyncio
+    async def test_leaves_node_scope_state_untouched(self):
+        companion = _scoped_radio_companion()
+        companion.set_default_flood_scope("nl-li", get_auto_key_for("#nl-li"))
+        companion.set_flood_region("#europe")
+        companion.set_flood_unscoped()
+        before = (
+            companion._flood_transport_key,
+            companion._flood_unscoped,
+            companion.prefs.default_scope_name,
+            companion.prefs.default_scope_key,
+        )
+
+        await _send_via_radio(companion, 0, "hello", flood_scope_key=get_auto_key_for("#USA"))
+
+        assert (
+            companion._flood_transport_key,
+            companion._flood_unscoped,
+            companion.prefs.default_scope_name,
+            companion.prefs.default_scope_key,
+        ) == before
+
+    @pytest.mark.asyncio
+    async def test_next_send_returns_to_node_scope(self):
+        """The override lasts exactly one message."""
+        companion = _scoped_radio_companion()
+        companion.set_flood_region("#nl-li")
+        nl_key = get_auto_key_for("#nl-li")
+
+        await _send_via_radio(companion, 0, "one", flood_scope_key=get_auto_key_for("#USA"))
+        pkt = await _send_via_radio(companion, 0, "two")
+
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt.transport_codes[0] == calc_transport_code(nl_key, pkt)
+
+    @pytest.mark.asyncio
+    async def test_without_keyword_is_unchanged(self):
+        companion = _scoped_radio_companion()
+
+        pkt = await _send_via_radio(companion, 0, "hello")
+
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+        assert pkt.transport_codes == [0, 0]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_key",
+        [b"", b"\x01" * 15, b"\x01" * 17, bytes(16)],
+        ids=["empty", "short", "long", "all-zero"],
+    )
+    async def test_bad_key_raises_before_any_rf(self, bad_key):
+        """ValueError must reach the caller, not be swallowed into `False`."""
+        companion = _scoped_radio_companion()
+
+        await companion.start()
+        try:
+            with pytest.raises(ValueError):
+                await companion.send_channel_message(0, "hello", flood_scope_key=bad_key)
+        finally:
+            await companion.stop()
+
+        assert companion._radio.sent == []
+
+    @pytest.mark.asyncio
+    async def test_missing_channel_returns_false_without_rf(self):
+        companion = _scoped_radio_companion()
+
+        await companion.start()
+        try:
+            ok = await companion.send_channel_message(
+                9, "hello", flood_scope_key=get_auto_key_for("#USA")
+            )
+        finally:
+            await companion.stop()
+
+        assert ok is False
+        assert companion._radio.sent == []
+
+
+class TestExplicitScopeOnBridge:
+    """The same behaviour through CompanionBridge's packet injector."""
+
+    @pytest.mark.asyncio
+    async def test_injected_packet_is_scoped(self):
+        bridge, sent = _capturing_bridge()
+        key = get_auto_key_for("#USA")
+
+        assert await bridge.send_channel_message(0, "hello", flood_scope_key=key) is True
+
+        assert len(sent) == 1
+        assert sent[0].get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert sent[0].transport_codes[0] == calc_transport_code(key, sent[0])
+
+    @pytest.mark.asyncio
+    async def test_marked_applied_so_host_dispatcher_cannot_replace_it(self):
+        """A repeater's dispatcher re-scopes floods; the mark is what stops it."""
+        bridge, sent = _capturing_bridge()
+
+        await bridge.send_channel_message(0, "hello", flood_scope_key=get_auto_key_for("#USA"))
+
+        assert sent[0]._flood_scope_applied is True
+
+    @pytest.mark.asyncio
+    async def test_concurrent_sends_do_not_cross_contaminate(self):
+        """Three overlapping sends, three different scopes, one packet each."""
+        release = asyncio.Event()
+        sent: list[Packet] = []
+
+        async def injector(pkt, **kwargs):
+            await release.wait()
+            sent.append(pkt)
+            return True
+
+        bridge = _make_bridge(injector)
+        bridge.set_flood_region("#nl-li")
+        usa, europe = get_auto_key_for("#USA"), get_auto_key_for("#europe")
+
+        tasks = [
+            asyncio.create_task(bridge.send_channel_message(0, "a", 1, flood_scope_key=usa)),
+            asyncio.create_task(bridge.send_channel_message(0, "b", 2, flood_scope_key=europe)),
+            asyncio.create_task(bridge.send_channel_message(0, "c", 3)),
+        ]
+        await asyncio.sleep(0)
+        release.set()
+        assert all(await asyncio.gather(*tasks))
+
+        by_code = {p.transport_codes[0] for p in sent}
+        assert len(sent) == 3
+        assert len(by_code) == 3, "concurrent sends shared a scope"
+        for pkt in sent:
+            assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        expected = {
+            calc_transport_code(k, p)
+            for k, p in zip((usa, europe, get_auto_key_for("#nl-li")), sent)
+        }
+        assert by_code == expected
+
+    @pytest.mark.asyncio
+    async def test_cancelled_send_leaves_no_residue(self):
+        """A send cancelled mid-injection must not alter the next send's scope."""
+        started = asyncio.Event()
+        sent: list[Packet] = []
+
+        async def injector(pkt, **kwargs):
+            started.set()
+            await asyncio.sleep(3600)
+            sent.append(pkt)  # pragma: no cover - cancelled first
+            return True
+
+        bridge = _make_bridge(injector)
+        task = asyncio.create_task(
+            bridge.send_channel_message(0, "a", flood_scope_key=get_auto_key_for("#USA"))
+        )
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert bridge._flood_transport_key is None
+        assert bridge._flood_unscoped is False
+
+    @pytest.mark.asyncio
+    async def test_injector_failure_reports_false(self):
+        async def injector(pkt, **kwargs):
+            return False
+
+        bridge = _make_bridge(injector)
+
+        ok = await bridge.send_channel_message(0, "hello", flood_scope_key=get_auto_key_for("#USA"))
+
+        assert ok is False

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -16,6 +16,7 @@ from openhop_core.companion.constants import (
     CMD_HAS_CONNECTION,
     CMD_IMPORT_PRIVATE_KEY,
     CMD_LOGOUT,
+    CMD_SEND_CHANNEL_TXT_MSG,
     CMD_SET_ADVERT_NAME,
     CMD_SET_TUNING_PARAMS,
     CMD_SIGN_DATA,
@@ -27,9 +28,14 @@ from openhop_core.companion.constants import (
     ERR_CODE_TABLE_FULL,
     ERR_CODE_UNSUPPORTED_CMD,
     FRAME_OUTBOUND_PREFIX,
+    MAX_FRAME_SIZE,
     MAX_PATH_SIZE,
     MAX_PAYLOAD_SIZE,
     MAX_SIGN_DATA_SIZE,
+    OPENHOP_CHANNEL_SCOPE_PROBE,
+    OPENHOP_CHANNEL_TXT_SCOPED,
+    OPENHOP_EXTENSION_MARKER,
+    OPENHOP_SCOPE_PROBE_RESERVED_LEN,
     PUB_KEY_SIZE,
     PUSH_CODE_ADVERT,
     PUSH_CODE_BINARY_RESPONSE,
@@ -53,6 +59,7 @@ from openhop_core.companion.constants import (
     RESP_CODE_ERR,
     RESP_CODE_NO_MORE_MESSAGES,
     RESP_CODE_OK,
+    RESP_CODE_OPENHOP_EXTENSION,
     RESP_CODE_SELF_INFO,
     RESP_CODE_SENT,
     RESP_CODE_SIGN_START,
@@ -74,6 +81,7 @@ from openhop_core.companion.models import (
     SentResult,
 )
 from openhop_core.protocol.packet_utils import PathUtils
+from openhop_core.protocol.transport_keys import get_auto_key_for
 
 
 def test_build_advert_push_frames_short_only_when_no_name():
@@ -3782,3 +3790,204 @@ async def test_cmd_send_trace_path_bridge_exception_is_illegal_arg():
     server, frames = _make_capture_server(bridge)
     await server._cmd_send_trace_path(_trace_frame())
     assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_ILLEGAL_ARG])]
+
+
+# ---------------------------------------------------------------------------
+# openHop extensions on CMD_SEND_CHANNEL_TXT_MSG (see docs/openhop-frame-extensions.md)
+# ---------------------------------------------------------------------------
+
+_EXT_PUBKEY = bytes(range(32))
+_EXT_KEY = get_auto_key_for("#USA")
+
+
+def _ext_server(send_result=True, channel=True):
+    """Capture server whose bridge accepts scoped channel sends."""
+    bridge = Mock()
+    bridge.get_public_key = Mock(return_value=_EXT_PUBKEY)
+    bridge.get_channel = Mock(
+        return_value=Channel(name="general", secret=bytes(16)) if channel else None
+    )
+    bridge.send_channel_message = AsyncMock(return_value=send_result)
+    server, frames = _make_capture_server(bridge)
+    return server, frames, bridge
+
+
+def _probe_payload(reserved=bytes(OPENHOP_SCOPE_PROBE_RESERVED_LEN)):
+    return bytes([OPENHOP_CHANNEL_SCOPE_PROBE]) + reserved
+
+
+def _scoped_payload(channel_idx=1, timestamp=1234, key=_EXT_KEY, text=b"hello"):
+    return (
+        bytes([OPENHOP_CHANNEL_TXT_SCOPED, channel_idx])
+        + struct.pack("<I", timestamp)
+        + key
+        + text
+    )
+
+
+@pytest.mark.asyncio
+async def test_openhop_scope_probe_returns_contract_marker_and_pubkey():
+    server, frames, _ = _ext_server()
+
+    await server._cmd_send_channel_txt_msg(_probe_payload())
+
+    assert frames == [
+        bytes([RESP_CODE_OPENHOP_EXTENSION]) + OPENHOP_EXTENSION_MARKER + _EXT_PUBKEY
+    ]
+    assert len(frames[0]) == 1 + 6 + PUB_KEY_SIZE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        bytes([OPENHOP_CHANNEL_SCOPE_PROBE]) + bytes(4),  # short: caught by len < 6
+        bytes([OPENHOP_CHANNEL_SCOPE_PROBE]) + bytes(6),  # long
+        bytes([OPENHOP_CHANNEL_SCOPE_PROBE]) + b"\x00\x01\x00\x00\x00",  # reserved not zero
+    ],
+    ids=["short", "long", "dirty-reserved"],
+)
+async def test_openhop_scope_probe_malformed_is_illegal_arg(payload):
+    server, frames, bridge = _ext_server()
+
+    await server._cmd_send_channel_txt_msg(payload)
+
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_ILLEGAL_ARG])]
+    bridge.send_channel_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_openhop_scoped_send_delegates_key_and_timestamp():
+    server, frames, bridge = _ext_server()
+
+    await server._cmd_send_channel_txt_msg(_scoped_payload())
+
+    assert frames == [bytes([RESP_CODE_OK])]
+    bridge.send_channel_message.assert_awaited_once_with(
+        1, "hello", timestamp=1234, flood_scope_key=_EXT_KEY
+    )
+
+
+@pytest.mark.asyncio
+async def test_openhop_scoped_send_strips_trailing_nuls():
+    """Trailing NULs are command 3's C-string convention, not an error."""
+    server, frames, bridge = _ext_server()
+
+    await server._cmd_send_channel_txt_msg(_scoped_payload(text=b"hello\x00\x00"))
+
+    assert frames == [bytes([RESP_CODE_OK])]
+    assert bridge.send_channel_message.await_args.args[1] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_openhop_scoped_send_unknown_channel_is_not_found():
+    server, frames, bridge = _ext_server(channel=False)
+
+    await server._cmd_send_channel_txt_msg(_scoped_payload(channel_idx=9))
+
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_NOT_FOUND])]
+    bridge.send_channel_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_openhop_scoped_send_failure_maps_to_not_found_like_cmd3():
+    server, frames, _ = _ext_server(send_result=False)
+
+    await server._cmd_send_channel_txt_msg(_scoped_payload())
+
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_NOT_FOUND])]
+
+
+@pytest.mark.asyncio
+async def test_openhop_scoped_send_value_error_maps_to_illegal_arg():
+    """An all-zero key reaches the bridge validator, not the radio."""
+    server, frames, bridge = _ext_server()
+    bridge.send_channel_message = AsyncMock(side_effect=ValueError("null key"))
+
+    await server._cmd_send_channel_txt_msg(_scoped_payload(key=bytes(16)))
+
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_ILLEGAL_ARG])]
+
+
+@pytest.mark.asyncio
+async def test_openhop_scoped_send_old_bridge_is_unsupported_not_unscoped():
+    """A bridge without the keyword must fail, never fall back to plain flood."""
+    server, frames, bridge = _ext_server()
+    bridge.send_channel_message = AsyncMock(side_effect=TypeError("unexpected keyword"))
+
+    await server._cmd_send_channel_txt_msg(_scoped_payload())
+
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_UNSUPPORTED_CMD])]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        bytes([OPENHOP_CHANNEL_TXT_SCOPED, 1]) + struct.pack("<I", 0) + _EXT_KEY[:8],
+        _scoped_payload(text=b""),
+        _scoped_payload(text=b"\x00\x00"),
+        _scoped_payload(text=b"hi\x00there"),
+        _scoped_payload(text=b"\xff\xfe"),
+        _scoped_payload(text=b"x" * 154),
+    ],
+    ids=["truncated-key", "empty-text", "only-nuls", "embedded-nul", "bad-utf8", "over-limit"],
+)
+async def test_openhop_scoped_send_rejects_malformed(payload):
+    server, frames, bridge = _ext_server()
+
+    await server._cmd_send_channel_txt_msg(payload)
+
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_ILLEGAL_ARG])]
+    bridge.send_channel_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_openhop_scoped_send_accepts_exact_frame_limit():
+    """153 text bytes is the largest payload that fits MAX_FRAME_SIZE."""
+    server, frames, bridge = _ext_server()
+    text = b"x" * 153
+    payload = _scoped_payload(text=text)
+    assert len(payload) + 1 == MAX_FRAME_SIZE
+
+    await server._cmd_send_channel_txt_msg(payload)
+
+    assert frames == [bytes([RESP_CODE_OK])]
+    assert bridge.send_channel_message.await_args.args[1] == text.decode()
+
+
+@pytest.mark.asyncio
+async def test_openhop_extensions_reachable_through_command_dispatch():
+    """The subtypes ride command 3, so they must arrive via _handle_cmd."""
+    server, frames, bridge = _ext_server()
+
+    await server._handle_cmd(bytes([CMD_SEND_CHANNEL_TXT_MSG]) + _probe_payload())
+    await server._handle_cmd(bytes([CMD_SEND_CHANNEL_TXT_MSG]) + _scoped_payload())
+
+    assert frames[0][0] == RESP_CODE_OPENHOP_EXTENSION
+    assert frames[1] == bytes([RESP_CODE_OK])
+    bridge.send_channel_message.assert_awaited_once_with(
+        1, "hello", timestamp=1234, flood_scope_key=_EXT_KEY
+    )
+
+
+@pytest.mark.asyncio
+async def test_plain_channel_txt_send_is_unchanged_by_extensions():
+    """Subtype 0 must not acquire a flood_scope_key kwarg."""
+    server, frames, bridge = _ext_server()
+
+    await server._cmd_send_channel_txt_msg(bytes([0, 1]) + struct.pack("<I", 1234) + b"hello")
+
+    assert frames == [bytes([RESP_CODE_OK])]
+    bridge.send_channel_message.assert_awaited_once_with(1, "hello", timestamp=1234)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("subtype", [0x04, 0x7F, 0x82, 0xFF])
+async def test_unknown_channel_txt_subtype_is_unsupported_without_rf(subtype):
+    server, frames, bridge = _ext_server()
+
+    await server._cmd_send_channel_txt_msg(bytes([subtype, 1]) + struct.pack("<I", 0) + b"x")
+
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_UNSUPPORTED_CMD])]
+    bridge.send_channel_message.assert_not_awaited()

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -36,6 +36,7 @@ from openhop_core.companion.constants import (
     OPENHOP_CHANNEL_TXT_SCOPED,
     OPENHOP_EXTENSION_MARKER,
     OPENHOP_SCOPE_PROBE_RESERVED_LEN,
+    OPENHOP_SCOPED_SEND_HEADER_LEN,
     PUB_KEY_SIZE,
     PUSH_CODE_ADVERT,
     PUSH_CODE_BINARY_RESPONSE,
@@ -68,6 +69,7 @@ from openhop_core.companion.constants import (
     RESP_CODE_TUNING_PARAMS,
     STATS_TYPE_PACKETS,
 )
+from openhop_core.companion import CompanionBridge
 from openhop_core.companion.frame_server import (
     CompanionFrameServer,
     _build_advert_push_frames,
@@ -80,6 +82,7 @@ from openhop_core.companion.models import (
     QueuedMessage,
     SentResult,
 )
+from openhop_core.protocol import LocalIdentity
 from openhop_core.protocol.packet_utils import PathUtils
 from openhop_core.protocol.transport_keys import get_auto_key_for
 
@@ -3991,3 +3994,50 @@ async def test_unknown_channel_txt_subtype_is_unsupported_without_rf(subtype):
 
     assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_UNSUPPORTED_CMD])]
     bridge.send_channel_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_openhop_scoped_send_bad_key_outranks_unknown_channel():
+    """A frame wrong in two ways reports the argument error, not NOT_FOUND.
+
+    Key validation runs before the channel lookup so a client told NOT_FOUND
+    can trust that its channel is the only thing to fix.
+    """
+    server, frames, bridge = _ext_server(channel=False)
+
+    await server._cmd_send_channel_txt_msg(_scoped_payload(channel_idx=9, key=bytes(16)))
+
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_ILLEGAL_ARG])]
+    bridge.send_channel_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_openhop_scoped_send_rejects_minimum_length_boundary():
+    """23 bytes is a complete header with no text; 24 is the real minimum."""
+    server, frames, bridge = _ext_server()
+    header = bytes([OPENHOP_CHANNEL_TXT_SCOPED, 1]) + struct.pack("<I", 0) + _EXT_KEY
+    # 23-byte payload = command byte + the 22 bytes this handler receives.
+    assert len(header) == OPENHOP_SCOPED_SEND_HEADER_LEN
+    assert len(header) + 1 == 23
+
+    await server._cmd_send_channel_txt_msg(header)
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_ILLEGAL_ARG])]
+
+    frames.clear()
+    await server._cmd_send_channel_txt_msg(header + b"x")
+    assert frames == [bytes([RESP_CODE_OK])]
+
+
+@pytest.mark.asyncio
+async def test_openhop_probe_returns_exactly_32_public_key_bytes_from_real_bridge():
+    """Against a real companion, not a Mock, so the frame length is pinned."""
+    bridge = CompanionBridge(LocalIdentity(), AsyncMock(return_value=True), node_name="probe")
+    server, frames = _make_capture_server(bridge)
+
+    await server._cmd_send_channel_txt_msg(_probe_payload())
+
+    assert len(frames) == 1
+    assert frames[0][0] == RESP_CODE_OPENHOP_EXTENSION
+    assert frames[0][1:7] == OPENHOP_EXTENSION_MARKER
+    assert frames[0][7:] == bridge.get_public_key()
+    assert len(frames[0]) == 1 + 6 + PUB_KEY_SIZE

--- a/tests/test_transport_compat.py
+++ b/tests/test_transport_compat.py
@@ -14,8 +14,19 @@ the algorithm is correct.  If not, there is a firmware-compatibility bug.
 
 from __future__ import annotations
 
-from openhop_core.protocol import Packet
-from openhop_core.protocol.transport_keys import calc_transport_code, get_auto_key_for
+import hashlib
+import hmac
+import struct
+
+import pytest
+
+from openhop_core.protocol import Packet, transport_keys
+from openhop_core.protocol.constants import ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD
+from openhop_core.protocol.transport_keys import (
+    calc_transport_code,
+    get_auto_key_for,
+    scope_packet,
+)
 
 # Raw GRP_TXT packet bytes captured from a firmware companion radio, region #nl-li.
 # Packet structure (TRANSPORT_FLOOD, path_len=0):
@@ -200,3 +211,126 @@ class TestTransportCodeDetails:
         assert (
             key == expected_full
         ), f"Key mismatch:\n  got      {key.hex()}\n  expected {expected_full.hex()}"
+
+
+# ---------------------------------------------------------------------------
+# Scoped GRP_TXT vectors, checked against an independent implementation
+# ---------------------------------------------------------------------------
+#
+# The tests above prove `calc_transport_code` reproduces one real firmware
+# capture. That is a single point, and it compares a helper against a captured
+# byte rather than against the algorithm: a change that broke, say, only the
+# reserved-value mapping or only uppercase names would still pass it.
+#
+# `_cpp_*` below re-implement TransportKeyStore::getAutoKeyFor and
+# TransportKey::calcTransportCode straight from the C++, using nothing from
+# openhop_core. They are anchored by `test_reference_impl_reproduces_capture`,
+# which shows the reference reproduces the same firmware capture the suite is
+# built on -- so the vectors it generates for regions we have no capture for
+# (notably an uppercase public region) carry that capture's authority.
+
+
+def _cpp_get_auto_key_for(name: str) -> bytes:
+    """MeshCore TransportKeyStore::getAutoKeyFor -- SHA-256(name)[:16]."""
+    return hashlib.sha256(name.encode("ascii")).digest()[:16]
+
+
+def _cpp_calc_transport_code(key: bytes, payload_type: int, payload: bytes) -> int:
+    """MeshCore TransportKey::calcTransportCode.
+
+    HMAC-SHA256 over payload_type || payload, first two bytes read as a
+    little-endian uint16 (Arduino endianness), with 0x0000 and 0xFFFF reserved.
+    """
+    digest = hmac.new(key, bytes([payload_type]) + payload, hashlib.sha256).digest()
+    code = struct.unpack("<H", digest[:2])[0]
+    if code == 0:
+        return 1
+    if code == 0xFFFF:
+        return 0xFFFE
+    return code
+
+
+# Frozen vectors over the captured firmware GRP_TXT payload above.
+# #USA and #usa are deliberately both present: they are different MeshCore
+# regions and must never produce the same key or code.
+SCOPED_VECTORS = [
+    ("#nl-li", "CE657DA0691CD4706A1435A950BC3D8B", 0xFBE5),
+    ("#USA", "5EAF24A29D2936601E22AC56065CB314", 0xE46D),
+    ("#usa", "418F6396CEA59E2CC79F06D1566EEC31", 0xF07F),
+]
+
+
+def _captured_grp_txt():
+    pkt = Packet()
+    assert pkt.read_from(bytes.fromhex(FIRMWARE_HEX))
+    return pkt
+
+
+class TestScopedGrpTxtVectors:
+    def test_reference_impl_reproduces_capture(self):
+        """Anchor: the from-scratch C++ port matches the real firmware bytes."""
+        pkt = _captured_grp_txt()
+        code = _cpp_calc_transport_code(
+            _cpp_get_auto_key_for(REGION), pkt.get_payload_type(), bytes(pkt.get_payload())
+        )
+        assert code == EXPECTED_FIRMWARE_CODE
+
+    @pytest.mark.parametrize("region,key_hex,code", SCOPED_VECTORS, ids=lambda v: str(v))
+    def test_vector_matches_reference_and_helpers(self, region, key_hex, code):
+        pkt = _captured_grp_txt()
+        expected_key = bytes.fromhex(key_hex)
+
+        # The frozen vector is what the C++ algorithm produces...
+        assert _cpp_get_auto_key_for(region) == expected_key
+        assert (
+            _cpp_calc_transport_code(expected_key, pkt.get_payload_type(), bytes(pkt.get_payload()))
+            == code
+        )
+        # ...and what openhop_core produces.
+        assert get_auto_key_for(region) == expected_key
+        assert calc_transport_code(expected_key, pkt) == code
+
+    def test_uppercase_and_lowercase_region_are_distinct(self):
+        """A client that case-folds a region name sends to the wrong mesh."""
+        pkt = _captured_grp_txt()
+        upper, lower = get_auto_key_for("#USA"), get_auto_key_for("#usa")
+
+        assert upper != lower
+        assert calc_transport_code(upper, pkt) != calc_transport_code(lower, pkt)
+
+    def test_scoped_send_emits_the_vector(self):
+        """End to end: the explicit override puts the vector's code on the wire.
+
+        Rebuilds the captured packet's route/codes the way
+        ``_apply_explicit_flood_scope`` does, so the full chain -- key, HMAC,
+        endianness, reserved values, route-type bits -- is asserted against a
+        firmware-anchored literal rather than against another helper.
+        """
+        pkt = _captured_grp_txt()
+        pkt.header = (pkt.header & ~0x03) | ROUTE_TYPE_FLOOD
+        pkt.transport_codes = [0, 0]
+
+        scope_packet(pkt, bytes.fromhex("5EAF24A29D2936601E22AC56065CB314"))
+
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt.transport_codes[0] == 0xE46D
+        assert pkt.transport_codes[1] == 0
+
+    @pytest.mark.parametrize(
+        "digest_head,expected",
+        [(b"\x00\x00", 0x0001), (b"\xff\xff", 0xFFFE)],
+        ids=["null-code", "broadcast-code"],
+    )
+    def test_reserved_codes_are_mapped_away(self, monkeypatch, digest_head, expected):
+        """0x0000 and 0xFFFF are reserved; firmware substitutes 0x0001/0xFFFE.
+
+        No region name is known to hash onto either, so the HMAC is forced to
+        land there -- otherwise this branch of calc_transport_code is never run.
+        """
+        monkeypatch.setattr(
+            transport_keys.CryptoUtils,
+            "_hmac_sha256",
+            staticmethod(lambda key, data: digest_head + bytes(30)),
+        )
+
+        assert calc_transport_code(get_auto_key_for("#USA"), _captured_grp_txt()) == expected


### PR DESCRIPTION
Implements a per-message flood scope for channel text messages: one explicit MeshCore transport key attached to one message, without disturbing the node's own scope settings.

## Why here

MeshCore has no per-message form of this. `MyMesh::sendFloodScoped` reads `send_unscoped` / `send_scope` / `default_scope_key` and carries a literal `// TODO: have per-channel send_scope` where one would go — so there is no firmware command to mirror, and the companion Frame side has to be an openHop extension.

Core is where it belongs regardless: channel packet construction and the companion Frame protocol are both owned here, and `openhop_repeater` inherits the behaviour with no feature code of its own.

## Python API

```python
await companion.send_channel_message(1, "hello", flood_scope_key=get_auto_key_for("#USA"))
```

`flood_scope_key=None` (the default) keeps today's resolution exactly: force-unscoped flag, then transient override, then persisted default, then plain flood. A 16-byte non-null key replaces all of that for one packet.

The override is packet-local. It is attached to the freshly built packet with no `await` in between and reads or writes no node, dispatcher, or preference state — so concurrent sends cannot see each other's scope, and a cancelled or failed send leaves nothing behind. It also sets `_flood_scope_applied`, which is what stops a host repeater's dispatcher re-scoping the message to its own region on the way out.

A key that is not exactly 16 non-zero bytes raises `ValueError`. That check runs **before** the send's `try` block on purpose: that handler turns every exception into `return False`, so validating inside it would hide a malformed key behind an ordinary transmit failure.

## RF output

Byte-identical to what firmware emits for a resolved `sendFloodScoped(scope, pkt)`:

- the `GRP_TXT` payload is built and encrypted unchanged — same channel hash, MAC, `"<sender>: "` prefix and truncation;
- route becomes `TRANSPORT_FLOOD`;
- slot 0 = `HMAC-SHA256(key, payload_type || payload)[:2]` little-endian, with `0x0000`/`0xFFFF` mapped to `0x0001`/`0xFFFE`;
- slot 1 stays 0.

## Frame extension

Two subtypes on `CMD_SEND_CHANNEL_TXT_MSG`'s `txt_type` byte with the high bit set — `0x80` scoped send, `0x81` capability probe. Riding command 3 rather than taking a command number means firmware and older Core builds reject them from their existing unsupported-`txt_type` branch, **before** touching the radio. Clients must see the `OHREG2` marker from the probe first.

`FIRMWARE_VER_CODE` deliberately does not move: it states MeshCore companion protocol compatibility, which is unchanged. Subtype 0 is byte-for-byte as before, with a test pinning that it does not acquire the new keyword.

Byte layouts, negotiation, and mixed-version behaviour: `docs/openhop-frame-extensions.md`.

## Region name case

`#USA` and `#usa` hash to different keys and are different MeshCore regions. Nothing here folds case, and the docs say plainly that clients must not either — a client that lowercases user input silently moves traffic to a region the user did not name.

## Design notes worth a reviewer's attention

- **All-zero keys raise** rather than meaning "plain flood" as `TransportKey::isNull()` does. An explicit per-message override has no reason to carry the null key, so zeros are far likelier to be an uninitialised buffer; the firmware-equivalent unscoped behaviour is still reachable via `CMD_SET_FLOOD_SCOPE` mode 1 or by omitting the override. This is the one deliberate divergence from firmware semantics.
- **Trailing NULs on the extension's text are stripped** (command 3's C-string convention), embedded NULs rejected.
- **An old bridge signature reports `ERR_CODE_UNSUPPORTED_CMD`** rather than falling back to an unscoped send, which would put the message on the wrong region silently.

## Tests

`1891 passed`; full pre-commit (black / isort / flake8 / pytest) green.

Coverage includes: explicit key wins over transient, default and force-unscoped state; stored prefs and dispatcher mirrors unchanged; concurrent sends with different keys not cross-contaminating; cancellation and injector failure leaving no residue; `ValueError` reaching the caller with nothing on the wire; and the whole Frame surface — probe, malformed probes, delegation, error mapping, truncated key, empty/NUL/invalid-UTF-8 text, the exact 176-byte boundary, and unknown subtypes never reaching RF. Exercised through both `CompanionRadio` and `CompanionBridge`.

On the firmware-compatibility vectors: no new firmware capture was available, so rather than compare two of our own helpers, a from-scratch port of the C++ key derivation and transport-code calculation (hashlib only) is first shown to reproduce the **existing real firmware capture** (`#nl-li` → `0xFBE5`), then used to pin frozen `#USA` / `#usa` vectors. The uppercase vector inherits that capture's authority but is not itself a capture — worth replacing with a real one if someone can grab it.

## Rollout

Merge and release Core first. The console/client then probes for `OHREG2`, derives public-region keys with exact case, and sends the raw 16-byte key. `openhop_repeater` needs no feature code — its full suite passes against this branch unmodified; a small wiring guard is proposed separately.
